### PR TITLE
Javascript object model for CSDL

### DIFF
--- a/examples/csdl-16.1.json
+++ b/examples/csdl-16.1.json
@@ -1,212 +1,212 @@
 {
-    "$Version": "4.0",
-    "$Reference": {
-        "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json": {
-            "$Include": [
-                {
-                    "$Namespace": "Org.OData.Core.V1",
-                    "$Alias": "Core",
-                    "@Core.DefaultNamespace": true
-                }
-            ]
-        },
-        "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.json": {
-            "$Include": [
-                {
-                    "$Namespace": "Org.OData.Measures.V1",
-                    "$Alias": "Measures"
-                }
-            ]
+  "$Version": "4.0",
+  "$Reference": {
+    "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json": {
+      "$Include": [
+        {
+          "$Namespace": "Org.OData.Core.V1",
+          "$Alias": "Core",
+          "@Core.DefaultNamespace": true
         }
+      ]
     },
-    "ODataDemo": {
-        "Product": {
-            "$Kind": "EntityType",
-            "$HasStream": true,
-            "$Key": [
-                "ID"
-            ],
-            "ID": {
-                "$Type": "Edm.Int32"
-            },
-            "Description": {
-                "$Nullable": true,
-                "@Core.IsLanguageDependent": true
-            },
-            "ReleaseDate": {
-                "$Type": "Edm.Date",
-                "$Nullable": true
-            },
-            "DiscontinuedDate": {
-                "$Type": "Edm.Date",
-                "$Nullable": true
-            },
-            "Rating": {
-                "$Type": "Edm.Int32",
-                "$Nullable": true
-            },
-            "Price": {
-                "$Type": "Edm.Decimal",
-                "$Nullable": true,
-                "@Measures.ISOCurrency": {
-                    "$Path": "Currency"
-                }
-            },
-            "Currency": {
-                "$Nullable": true,
-                "$MaxLength": 3
-            },
-            "Category": {
-                "$Kind": "NavigationProperty",
-                "$Type": "ODataDemo.Category",
-                "$Partner": "Products"
-            },
-            "Supplier": {
-                "$Kind": "NavigationProperty",
-                "$Type": "ODataDemo.Supplier",
-                "$Nullable": true,
-                "$Partner": "Products"
-            }
+    "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.json": {
+      "$Include": [
+        {
+          "$Namespace": "Org.OData.Measures.V1",
+          "$Alias": "Measures"
+        }
+      ]
+    }
+  },
+  "ODataDemo": {
+    "Product": {
+      "$Kind": "EntityType",
+      "$HasStream": true,
+      "$Key": ["ID", { "CatID": "Category/ID" }],
+      "ID": {
+        "$Type": "Edm.Int32"
+      },
+      "Description": {
+        "$Nullable": true,
+        "@Core.IsLanguageDependent": true
+      },
+      "ReleaseDate": {
+        "$Type": "Edm.Date",
+        "$Nullable": true
+      },
+      "DiscontinuedDate": {
+        "$Type": "Edm.Date",
+        "$Nullable": true
+      },
+      "Rating": {
+        "$Type": "Edm.Int32",
+        "$Nullable": true
+      },
+      "Price": {
+        "$Type": "Edm.Decimal",
+        "$Nullable": true,
+        "@Measures.ISOCurrency": {
+          "$Path": "Currency",
+          "@Core.Description": "Y"
         },
-        "Category": {
-            "$Kind": "EntityType",
-            "$Key": [
-                "ID"
-            ],
-            "ID": {
-                "$Type": "Edm.Int32"
-            },
-            "Name": {
-                "@Core.IsLanguageDependent": true
-            },
-            "Products": {
-                "$Kind": "NavigationProperty",
-                "$Collection": true,
-                "$Type": "ODataDemo.Product",
-                "$Partner": "Category",
-                "$OnDelete": "Cascade"
-            }
-        },
-        "Supplier": {
-            "$Kind": "EntityType",
-            "$Key": [
-                "ID"
-            ],
-            "ID": {},
-            "Name": {
-                "$Nullable": true
-            },
-            "Address": {
-                "$Type": "ODataDemo.Address"
-            },
-            "Concurrency": {
-                "$Type": "Edm.Int32"
-            },
-            "Products": {
-                "$Kind": "NavigationProperty",
-                "$Collection": true,
-                "$Type": "ODataDemo.Product",
-                "$Partner": "Supplier"
-            }
-        },
-        "Country": {
-            "$Kind": "EntityType",
-            "$Key": [
-                "Code"
-            ],
-            "Code": {
-                "$MaxLength": 2
-            },
-            "Name": {
-                "$Nullable": true
-            }
-        },
-        "Address": {
-            "$Kind": "ComplexType",
-            "Street": {
-                "$Nullable": true
-            },
-            "City": {
-                "$Nullable": true
-            },
-            "State": {
-                "$Nullable": true
-            },
-            "ZipCode": {
-                "$Nullable": true
-            },
-            "CountryName": {
-                "$Nullable": true
-            },
-            "Country": {
-                "$Kind": "NavigationProperty",
-                "$Type": "ODataDemo.Country",
-                "$Nullable": true,
-                "$ReferentialConstraint": {
-                    "CountryName": "Name"
-                }
-            }
-        },
-        "ProductsByRating": [
-            {
-                "$Kind": "Function",
-                "$Parameter": [
-                    {
-                        "$Name": "Rating",
-                        "$Type": "Edm.Int32",
-                        "$Nullable": true
-                    }
-                ],
-                "$ReturnType": {
-                    "$Collection": true,
-                    "$Type": "ODataDemo.Product"
-                }
-            }
+        "@Measures.ISOCurrency@Core.Description": "Z"
+      },
+      "Currency": {
+        "$Nullable": true,
+        "$MaxLength": 3
+      },
+      "Category": {
+        "$Kind": "NavigationProperty",
+        "$Type": "ODataDemo.Category",
+        "$Partner": "Products"
+      },
+      "Supplier": {
+        "$Kind": "NavigationProperty",
+        "$Type": "ODataDemo.Supplier",
+        "$Nullable": true,
+        "$Partner": "Products"
+      }
+    },
+    "EdibleProduct": {
+      "$Kind": "EntityType",
+      "$BaseType": "ODataDemo.Product",
+      "Rating": { "$Nullable": true }
+    },
+    "Category": {
+      "$Kind": "EntityType",
+      "$Key": ["ID"],
+      "ID": {
+        "$Type": "Edm.Int32"
+      },
+      "Name": {
+        "@Core.IsLanguageDependent": true
+      },
+      "Products": {
+        "$Kind": "NavigationProperty",
+        "$Collection": true,
+        "$Type": "ODataDemo.Product",
+        "$Partner": "Category",
+        "$OnDelete": "Cascade"
+      }
+    },
+    "Supplier": {
+      "$Kind": "EntityType",
+      "$Key": ["ID"],
+      "ID": {},
+      "Name": {
+        "$Nullable": true
+      },
+      "Address": {
+        "$Type": "ODataDemo.Address"
+      },
+      "Concurrency": {
+        "$Type": "Edm.Int32"
+      },
+      "Products": {
+        "$Kind": "NavigationProperty",
+        "$Collection": true,
+        "$Type": "ODataDemo.Product",
+        "$Partner": "Supplier"
+      }
+    },
+    "Country": {
+      "$Kind": "EntityType",
+      "$Key": ["Code"],
+      "Code": {
+        "$MaxLength": 2
+      },
+      "Name": {
+        "$Nullable": true
+      }
+    },
+    "Address": {
+      "$Kind": "ComplexType",
+      "Street": {
+        "$Nullable": true
+      },
+      "City": {
+        "$Nullable": true
+      },
+      "State": {
+        "$Nullable": true
+      },
+      "ZipCode": {
+        "$Nullable": true
+      },
+      "CountryName": {
+        "$Nullable": true
+      },
+      "Country": {
+        "$Kind": "NavigationProperty",
+        "$Type": "ODataDemo.Country",
+        "$Nullable": true,
+        "$ReferentialConstraint": {
+          "CountryName": "Name",
+          "CountryName@Core.Description": "X",
+          "CountryName@Core.Description@Core.IsLanguageDependent": false
+        }
+      }
+    },
+    "ProductsByRating": [
+      {
+        "$Kind": "Function",
+        "$Parameter": [
+          {
+            "$Name": "Rating",
+            "$Type": "Edm.Int32",
+            "$Nullable": true
+          }
         ],
-        "DemoService": {
-            "$Kind": "EntityContainer",
-            "Products": {
-                "$Collection": true,
-                "$Type": "ODataDemo.Product",
-                "$NavigationPropertyBinding": {
-                    "Category": "Categories"
-                }
-            },
-            "Categories": {
-                "$Collection": true,
-                "$Type": "ODataDemo.Category",
-                "$NavigationPropertyBinding": {
-                    "Products": "Products"
-                },
-                "@Core.Description": "Product Categories"
-            },
-            "Suppliers": {
-                "$Collection": true,
-                "$Type": "ODataDemo.Supplier",
-                "$NavigationPropertyBinding": {
-                    "Products": "Products",
-                    "Address/Country": "Countries"
-                },
-                "@Core.OptimisticConcurrency": [
-                    "Concurrency"
-                ]
-            },
-            "MainSupplier": {
-                "$Type": "ODataDemo.Supplier",
-                "$NavigationPropertyBinding": {
-                    "Products": "Products"
-                },
-                "@Core.Description": "Primary Supplier"
-            },
-            "Countries": {
-                "$Collection": true,
-                "$Type": "ODataDemo.Country"
-            },
-            "ProductsByRating": {
-                "$Function": "ODataDemo.ProductsByRating",
-                "$EntitySet": "Products"
-            }
+        "$ReturnType": {
+          "$Collection": true,
+          "$Type": "ODataDemo.Product"
         }
-    },
-    "$EntityContainer": "ODataDemo.DemoService"
+      }
+    ],
+    "DemoService": {
+      "$Kind": "EntityContainer",
+      "Products": {
+        "$Collection": true,
+        "$Type": "ODataDemo.Product",
+        "$NavigationPropertyBinding": {
+          "Category": "Categories"
+        }
+      },
+      "Categories": {
+        "$Collection": true,
+        "$Type": "ODataDemo.Category",
+        "$NavigationPropertyBinding": {
+          "Products": "Products"
+        },
+        "@Core.Description": "Product Categories",
+        "@Core.Description@Core.IsLanguageDependent": true
+      },
+      "Suppliers": {
+        "$Collection": true,
+        "$Type": "ODataDemo.Supplier",
+        "$NavigationPropertyBinding": {
+          "Products": "Products",
+          "Address/Country": "Countries"
+        },
+        "@Core.OptimisticConcurrency": ["Concurrency"]
+      },
+      "MainSupplier": {
+        "$Type": "ODataDemo.Supplier",
+        "$NavigationPropertyBinding": {
+          "Products": "Products"
+        },
+        "@Core.Description": "Primary Supplier"
+      },
+      "Countries": {
+        "$Collection": true,
+        "$Type": "ODataDemo.Country"
+      },
+      "ProductsByRating": {
+        "$Function": "ODataDemo.ProductsByRating",
+        "$EntitySet": "Products"
+      }
+    }
+  },
+  "$EntityContainer": "ODataDemo.DemoService"
 }

--- a/lib/metamodel.js
+++ b/lib/metamodel.js
@@ -2,6 +2,7 @@ class ModelElement {
   #children = {};
   #parent;
   #targetingPaths = new Set();
+  #targetingSegments = new Set();
   constructor(parent) {
     this.#parent = parent;
   }
@@ -14,24 +15,27 @@ class ModelElement {
   get parent() {
     return this.#parent;
   }
-  addChild(name, value) {
-    this.children[name] = value;
-    if (this[name] === undefined)
-      Object.defineProperty(this, name, {
-        get: () => this.children[name],
-      });
-  }
   /**
-   * @return {Set} set of #Path objects targeting this model element
+   * @return {Set} set of #Path objects that target this model element
    */
   get targetingPaths() {
     return this.#targetingPaths;
   }
+  /**
+   * @return {Set} set of #Segment objects that are non-final in their path
+   * and target this model element
+   */
+  get targetingSegments() {
+    return this.#targetingSegments;
+  }
   evaluate(path, offset = 0) {
     let target = this;
-    for (let i = offset; target && i < path.segments.length; i++)
+    for (let i = offset; i < path.segments.length; i++) {
       target = path.segments[i].evaluate(target);
-    if (!target) throw new InvalidPathError(path);
+      if (!target) throw new InvalidPathError(path);
+      if (i < path.segments.length - 1)
+        target.targetingSegments.add(path.segments[i]);
+    }
     target.targetingPaths.add(path);
     return target;
   }
@@ -48,7 +52,7 @@ class ModelElement {
         this[member].fromJSON(json[member]);
       } else if (!member.startsWith("$")) {
         if (json[member] instanceof Array) {
-          this.addChild(member, []);
+          this.children[member] = [];
           for (const item of json[member]) {
             const memberItem = new closure[item.$Kind](this);
             memberItem.fromJSON(item);
@@ -61,7 +65,7 @@ class ModelElement {
               ? defaultKind(json[member])
               : defaultKind);
           if (kind) new closure[kind](this, member);
-          else this.addChild(member, new ModelElement(this));
+          else this.children[member] = new ModelElement(this);
           this.children[member].fromJSON(json[member]);
         }
       } else if (!this[member] && typeof json[member] !== "object")
@@ -81,7 +85,7 @@ class NamedModelElement extends ModelElement {
   constructor(parent, name) {
     super(parent);
     this.#name = name;
-    parent.addChild(name, this);
+    parent.children[name] = this;
   }
 }
 
@@ -137,6 +141,7 @@ class Segment {
     );
   }
   evaluate(modelElement) {
+    if (!modelElement.evaluateSegment) throw new InvalidPathError(this.#path);
     return (this.#target = modelElement.evaluateSegment(this.#segment));
   }
   toJSON() {
@@ -323,7 +328,7 @@ class Annotation extends Namespaced {
 class Schema extends Namespaced {
   constructor(csdlDocument, namespace) {
     super(csdlDocument, namespace);
-    csdlDocument.addChild(namespace, this);
+    csdlDocument.children[namespace] = this;
   }
   get schema() {
     return this;
@@ -388,6 +393,9 @@ class ComplexType extends NamedModelElement {
       this.children[segment] || this.$BaseType.target.evaluateSegment(segment)
     );
   }
+  /**
+   * @return {ComplexType} structured type containing also the inherited properties
+   */
   effectiveType() {
     if (!this.$BaseType) return this;
     const props = { ...this.$BaseType.effectiveType };
@@ -399,7 +407,7 @@ class ComplexType extends NamedModelElement {
       new ModelElement(this),
       this.name,
     );
-    for (const prop in props) effectiveType.addChild(prop, props[prop]);
+    for (const prop in props) effectiveType.children[prop] = props[prop];
     return effectiveType;
   }
   fromJSON(json) {
@@ -482,10 +490,16 @@ class PropertyRef extends NamedModelElement {
   }
 }
 
-class Property extends NamedModelElement {
+class AbstractProperty extends NamedModelElement {
+  evaluateSegment(segment) {
+    return this.$Type.target.evaluateSegment(segment);
+  }
   evaluationStart() {
     return this.parent;
   }
+}
+
+class Property extends AbstractProperty {
   fromJSON(json) {
     super.fromJSON(json);
     this.$Type = new NamespacePath(this, json.$Type || "Edm.String");
@@ -497,7 +511,7 @@ class Property extends NamedModelElement {
   }
 }
 
-class NavigationProperty extends NamedModelElement {
+class NavigationProperty extends AbstractProperty {
   fromJSON(json) {
     super.fromJSON(json);
     this.$Type = new NamespacePath(this, json.$Type);
@@ -532,19 +546,32 @@ class EntitySetOrSingleton extends NamedModelElement {
 }
 
 class NavigationPropertyBinding extends NamedSubElement {
-  #path;
+  #navigationProperty;
+  #entitySet;
   constructor(entitySetOrSingleton, prop) {
     super(entitySetOrSingleton, "$NavigationPropertyBinding", prop);
   }
-  get path() {
-    return this.#path;
+  get navigationProperty() {
+    return this.#navigationProperty;
+  }
+  get entitySet() {
+    return this.#entitySet;
   }
   fromJSON(json) {
     // TODO: $NavigationPropertyBinding annotations
-    this.#path = new RelativePath(this, json[this.name], this.parent.parent);
+    this.#navigationProperty = new RelativePath(
+      this,
+      this.name,
+      this.parent.$Type.target,
+    );
+    this.#entitySet = new RelativePath(
+      this,
+      json[this.name],
+      this.parent.parent,
+    );
   }
   toJSON() {
-    return this.path.toJSON();
+    return this.entitySet.toJSON();
   }
 }
 
@@ -569,6 +596,7 @@ function CSDLReviver(key, value) {
 }
 
 const closure = (module.exports = {
+  InvalidPathError,
   RelativePath,
   NamespacePath,
   CSDLDocument,

--- a/lib/metamodel.js
+++ b/lib/metamodel.js
@@ -1,4 +1,4 @@
-const schemas = new Map();
+const csdlDocuments = new Map();
 
 class ModelElement {
   #children = {};
@@ -133,7 +133,13 @@ class NamedValue extends NamedModelElement {
 }
 
 class CSDLDocument extends ModelElement {
+  #uri;
   #paths = [];
+  #finish;
+  constructor(uri) {
+    super();
+    this.#uri = uri || "";
+  }
   get csdlDocument() {
     return this;
   }
@@ -157,8 +163,8 @@ class CSDLDocument extends ModelElement {
         for (const uri in this.$Reference)
           for (const include of this.$Reference[uri].$Include)
             if ([include.$Alias, include.$Namespace].includes(namespace)) {
-              target = schemas.get(include.$Namespace).children[name];
-              break reference;
+              target = include.schema.children[name];
+              if (target) break reference;
             }
       }
     return target;
@@ -166,15 +172,31 @@ class CSDLDocument extends ModelElement {
   /** Await this before addressing #AbstractPath.target, #ModelElement.targetingPaths
    * or #ModelElement.targetingSegments
    */
-  async finish() {
-    if (this.#paths !== "finished") {
+  finish() {
+    if (!this.#finish) {
+      let finished;
+      this.#finish = new Promise(function (resolve, reject) {
+        finished = resolve;
+      });
       const references = [];
       for (const uri in this.$Reference)
         references.push(this.$Reference[uri].resolve());
-      await Promise.all(references);
-      for (const path of this.paths) path.target;
-      this.#paths = "finished";
+      Promise.all(references).then(
+        async function (uris) {
+          for (const path of this.paths) path.target;
+          this.#paths = undefined;
+          await Promise.all(
+            uris
+              .filter((uri) => uri > this.#uri)
+              .map((uri) =>
+                csdlDocuments.get(uri).then((csdl) => csdl.finish()),
+              ),
+          );
+          finished();
+        }.bind(this),
+      );
     }
+    return this.#finish;
   }
   fromJSON(json) {
     super.fromJSON(json, "Schema");
@@ -238,8 +260,7 @@ class AbstractPath extends ModelElement {
 class NamespacePath extends AbstractPath {
   constructor(host, path) {
     super(host, path);
-    if (this.csdlDocument.paths !== "finished")
-      this.csdlDocument.paths.unshift(this);
+    this.csdlDocument.paths?.unshift(this);
   }
   evaluate() {
     const { namespace, name } = this.segments[0].qualifiedName();
@@ -259,8 +280,7 @@ class RelativePath extends AbstractPath {
   constructor(host, path, relativeTo) {
     super(host, path);
     this.#relativeTo = relativeTo;
-    if (this.csdlDocument.paths !== "finished")
-      this.csdlDocument.paths.push(this);
+    this.csdlDocument.paths?.push(this);
   }
   evaluate() {
     const target = this.#relativeTo.evaluate(this);
@@ -287,15 +307,23 @@ class Reference extends ModelElement {
     return this.#uri;
   }
   async resolve() {
-    if (this.$Include) {
-      if (this.$Include.some((include) => !schemas.get(include.$Namespace))) {
-        const csdl = new CSDLDocument();
-        csdl.fromJSON(await (await fetch(this.uri)).json());
-        await csdl.finish();
-      }
+    let csdl = csdlDocuments.get(this.uri);
+    if (!csdl)
+      csdlDocuments.set(
+        this.uri,
+        (csdl = new Promise(
+          async function (resolve, reject) {
+            const csdl = new CSDLDocument(this.uri);
+            csdl.fromJSON(await (await fetch(this.uri)).json());
+            resolve(csdl);
+          }.bind(this),
+        )),
+      );
+    csdl = await csdl;
+    if (this.$Include)
       for (const include of this.$Include)
-        include.schema = schemas.get(include.$Namespace);
-    }
+        include.schema = csdl.children[include.$Namespace];
+    return this.uri;
   }
   fromJSON(json) {
     super.fromJSON(json);
@@ -307,7 +335,15 @@ class Reference extends ModelElement {
   }
 }
 
-class Include extends ModelElement {
+class ListedModelElement extends ModelElement {
+  constructor(parent, list) {
+    super(parent);
+    parent[list] ||= [];
+    parent[list].push(this);
+  }
+}
+
+class Include extends ListedModelElement {
   #schema;
   get schema() {
     return this.#schema;
@@ -316,17 +352,13 @@ class Include extends ModelElement {
     this.#schema = schema;
   }
   constructor(reference) {
-    super(reference);
-    if (!reference.$Include) reference.$Include = [];
-    reference.$Include.push(this);
+    super(reference, "$Include");
   }
 }
 
-class IncludeAnnotations extends ModelElement {
+class IncludeAnnotations extends ListedModelElement {
   constructor(reference) {
-    super(reference);
-    if (!reference.$IncludeAnnotations) reference.$IncludeAnnotations = [];
-    reference.$IncludeAnnotations.push(this);
+    super(reference, "$IncludeAnnotations");
   }
 }
 
@@ -374,12 +406,7 @@ class Annotation extends ModelElement {
   }
 }
 
-class Schema extends NamedModelElement {
-  constructor(csdlDocument, namespace) {
-    super(csdlDocument, namespace);
-    schemas.set(namespace, this);
-  }
-}
+class Schema extends NamedModelElement {}
 
 class Record extends ModelElement {
   fromJSON(json) {
@@ -619,7 +646,37 @@ class NavigationPropertyBinding extends NamedSubElement {
   }
 }
 
-class Function extends ModelElement {}
+class Operation extends ModelElement {
+  fromJSON(json) {
+    if (json.$Parameter) {
+      for (const param of json.$Parameter) new Parameter(this).fromJSON(param);
+    }
+    if (json.$ReturnType) {
+      this.$ReturnType = new ReturnType(this);
+      this.$ReturnType.fromJSON(json.$ReturnType);
+    }
+    super.fromJSON(json);
+  }
+}
+
+class Parameter extends ListedModelElement {
+  constructor(operation) {
+    super(operation, "$Parameter");
+  }
+  fromJSON(json) {
+    this.$Type = new NamespacePath(this, json.$Type);
+    super.fromJSON(json);
+  }
+}
+
+class ReturnType extends ModelElement {
+  fromJSON(json) {
+    this.$Type = new NamespacePath(this, json.$Type);
+    super.fromJSON(json);
+  }
+}
+
+class Function extends Operation {}
 
 class FunctionImport extends NamedModelElement {
   fromJSON(json) {

--- a/lib/metamodel.js
+++ b/lib/metamodel.js
@@ -1,3 +1,5 @@
+const schemas = new Map();
+
 class ModelElement {
   #children = {};
   #parent;
@@ -16,7 +18,7 @@ class ModelElement {
     return this.#parent;
   }
   /**
-   * @return {Set} set of #Path objects that target this model element
+   * @return {Set} set of #AbstractPath objects that target this model element
    */
   get targetingPaths() {
     return this.#targetingPaths;
@@ -40,16 +42,20 @@ class ModelElement {
     return target;
   }
   fromJSON(json, defaultKind) {
+    const annos = {};
     for (const member in json) {
-      const m = member.match(/^(.*)@(.*?)\.(.*?)(#(.*?))?$/);
+      const m = member.match(/^(.*)@(.*?)(#(.*?))?$/);
       if (m) {
-        this[member] = new Annotation(
+        const anno = new Annotation(
           m[1] ? new RelativePath(this, m[1], this).evaluate() : this,
           m[2],
-          m[3],
-          m[5],
+          m[4],
         );
-        this[member].fromJSON(json[member]);
+        anno.fromJSON(json[member]);
+        if (m[1]) {
+          annos[m[1]] ||= {};
+          annos[m[1]][m[2] + (m[3] || "")] = anno;
+        } else this[member] = anno;
       } else if (!member.startsWith("$")) {
         if (json[member] instanceof Array) {
           this.children[member] = [];
@@ -71,6 +77,12 @@ class ModelElement {
       } else if (!this[member] && typeof json[member] !== "object")
         this[member] = json[member];
     }
+    for (const member in annos)
+      for (const a in annos[member]) {
+        const target = this[member] || this.children[member];
+        if (typeof target === "object") target["@" + a] = annos[member][a];
+        else this[member + "@" + a] = annos[member][a];
+      }
   }
   toJSON() {
     return { ...this, ...this.children };
@@ -81,6 +93,9 @@ class NamedModelElement extends ModelElement {
   #name;
   get name() {
     return this.#name;
+  }
+  evaluateSegment(segment) {
+    return this.children[segment];
   }
   constructor(parent, name) {
     super(parent);
@@ -97,6 +112,26 @@ class NamedSubElement extends NamedModelElement {
   }
 }
 
+class NamedValue extends NamedModelElement {
+  #value;
+  get value() {
+    return this.#value;
+  }
+  static toJSONWithAnnotations(modelElement, json) {
+    for (const member in modelElement.children)
+      for (const anno in modelElement.children[member])
+        if (anno.startsWith("@"))
+          json[member + anno] = modelElement.children[member][anno];
+    return json;
+  }
+  fromJSON(json) {
+    this.#value = json;
+  }
+  toJSON() {
+    return this.value;
+  }
+}
+
 class CSDLDocument extends ModelElement {
   #paths = [];
   get csdlDocument() {
@@ -105,9 +140,41 @@ class CSDLDocument extends ModelElement {
   get paths() {
     return this.#paths;
   }
-  finish() {
-    for (const path of this.paths) path.target;
-    this.#paths = undefined;
+  byQualifiedName(namespace, name) {
+    let target;
+    for (const schema in this.children)
+      if (
+        !schema.startsWith("$") &&
+        [this.children[schema].$Alias, this.children[schema].name].includes(
+          namespace,
+        )
+      ) {
+        target = this.children[schema].children[name];
+        break;
+      }
+    if (!target)
+      reference: {
+        for (const uri in this.$Reference)
+          for (const include of this.$Reference[uri].$Include)
+            if ([include.$Alias, include.$Namespace].includes(namespace)) {
+              target = schemas.get(include.$Namespace).children[name];
+              break reference;
+            }
+      }
+    return target;
+  }
+  /** Await this before addressing #AbstractPath.target, #ModelElement.targetingPaths
+   * or #ModelElement.targetingSegments
+   */
+  async finish() {
+    if (this.#paths !== "finished") {
+      const references = [];
+      for (const uri in this.$Reference)
+        references.push(this.$Reference[uri].resolve());
+      await Promise.all(references);
+      for (const path of this.paths) path.target;
+      this.#paths = "finished";
+    }
   }
   fromJSON(json) {
     super.fromJSON(json, "Schema");
@@ -171,25 +238,18 @@ class AbstractPath extends ModelElement {
 class NamespacePath extends AbstractPath {
   constructor(host, path) {
     super(host, path);
-    this.csdlDocument.paths?.unshift(this);
+    if (this.csdlDocument.paths !== "finished")
+      this.csdlDocument.paths.unshift(this);
   }
   evaluate() {
     const { namespace, name } = this.segments[0].qualifiedName();
-    if (namespace === "Edm") return this.segments[0];
-    let target;
-    for (const schema in this.csdlDocument.children)
-      if (
-        !schema.startsWith("$") &&
-        (this.csdlDocument.children[schema].$Alias === namespace ||
-          this.csdlDocument.children[schema].namespace === namespace)
-      ) {
-        target = this.csdlDocument.children[schema].children[name];
-        if (target instanceof Array)
-          target = target.some((t) => t.evaluate(this, 1));
-        else target = target.evaluate(this, 1);
-        break;
-      }
+    if (["Edm", "odata"].includes(namespace)) return this.segments[0];
+    let target = this.csdlDocument.byQualifiedName(namespace, name);
     if (!target) throw new InvalidPathError(this);
+    // TODO: Address operation overloads
+    if (target instanceof Array)
+      target = target.some((t) => t.evaluate(this, 1));
+    else target = target.evaluate(this, 1);
     return (this.segments[0].target = target);
   }
 }
@@ -199,7 +259,8 @@ class RelativePath extends AbstractPath {
   constructor(host, path, relativeTo) {
     super(host, path);
     this.#relativeTo = relativeTo;
-    this.csdlDocument.paths?.push(this);
+    if (this.csdlDocument.paths !== "finished")
+      this.csdlDocument.paths.push(this);
   }
   evaluate() {
     const target = this.#relativeTo.evaluate(this);
@@ -218,11 +279,23 @@ class Reference extends ModelElement {
   #uri;
   constructor(csdlDocument, uri) {
     super(csdlDocument);
+    this.#uri = uri;
     csdlDocument.$Reference ||= {};
     csdlDocument.$Reference[uri] = this;
   }
   get uri() {
     return this.#uri;
+  }
+  async resolve() {
+    if (this.$Include) {
+      if (this.$Include.some((include) => !schemas.get(include.$Namespace))) {
+        const csdl = new CSDLDocument();
+        csdl.fromJSON(await (await fetch(this.uri)).json());
+        await csdl.finish();
+      }
+      for (const include of this.$Include)
+        include.schema = schemas.get(include.$Namespace);
+    }
   }
   fromJSON(json) {
     super.fromJSON(json);
@@ -235,6 +308,13 @@ class Reference extends ModelElement {
 }
 
 class Include extends ModelElement {
+  #schema;
+  get schema() {
+    return this.#schema;
+  }
+  set schema(schema) {
+    this.#schema = schema;
+  }
   constructor(reference) {
     super(reference);
     if (!reference.$Include) reference.$Include = [];
@@ -250,48 +330,17 @@ class IncludeAnnotations extends ModelElement {
   }
 }
 
-class Namespaced extends ModelElement {
-  #namespace;
-  constructor(csdlDocument, namespace) {
-    super(csdlDocument);
-    this.#namespace = namespace;
-  }
-  #include() {
-    for (const schema in this.csdlDocument.children)
-      if (
-        !schema.startsWith("$") &&
-        (this.#namespace === this.csdlDocument.children[schema].$Alias ||
-          this.#namespace === schema)
-      )
-        return { namespace: this.csdlDocument.children[schema].#namespace };
-    for (const url in this.csdlDocument.$Reference) {
-      if (this.csdlDocument.$Reference[url].$Include)
-        for (const include of this.csdlDocument.$Reference[url].$Include)
-          if (
-            this.#namespace === include.$Alias ||
-            this.#namespace === include.$Namespace
-          )
-            return { url, namespace: include.$Namespace };
-    }
-  }
-  get namespace() {
-    return this.#include().namespace;
-  }
-  get namespaceURL() {
-    return this.#include().url;
-  }
-}
-
-class Annotation extends Namespaced {
-  #target;
+class Annotation extends ModelElement {
   #term;
   #qualifier;
   #value;
-  constructor(target, namespace, term, qualifier) {
-    super(target, namespace);
-    this.#target = target;
-    this.#term = term;
+  constructor(target, term, qualifier) {
+    super(target);
+    this.#term = new NamespacePath(this, term);
     this.#qualifier = qualifier;
+  }
+  get term() {
+    return this.#term;
   }
   get value() {
     return this.#value;
@@ -300,7 +349,7 @@ class Annotation extends Namespaced {
     this.#value = value;
   }
   evaluationStart() {
-    return this.#target.evaluationStart();
+    return this.parent.evaluationStart();
   }
   fromJSON(json) {
     if (typeof json === "object") {
@@ -311,7 +360,7 @@ class Annotation extends Namespaced {
               this.value = new Path(
                 this,
                 json[dynamicExpr],
-                this.#target.evaluationStart(),
+                this.parent.evaluationStart(),
               );
               break dynamic;
           }
@@ -325,13 +374,10 @@ class Annotation extends Namespaced {
   }
 }
 
-class Schema extends Namespaced {
+class Schema extends NamedModelElement {
   constructor(csdlDocument, namespace) {
     super(csdlDocument, namespace);
-    csdlDocument.children[namespace] = this;
-  }
-  get schema() {
-    return this;
+    schemas.set(namespace, this);
   }
 }
 
@@ -390,7 +436,8 @@ class Path extends ModelElement {
 class ComplexType extends NamedModelElement {
   evaluateSegment(segment) {
     return (
-      this.children[segment] || this.$BaseType.target.evaluateSegment(segment)
+      super.evaluateSegment(segment) ||
+      this.$BaseType.target.evaluateSegment(segment)
     );
   }
   /**
@@ -445,7 +492,6 @@ class Key extends ModelElement {
     this.#entityType = entityType;
   }
   fromJSON(json) {
-    // TODO: $Key annotations
     for (const prop of json) {
       let propRef;
       if (typeof prop === "string")
@@ -490,10 +536,17 @@ class PropertyRef extends NamedModelElement {
   }
 }
 
-class AbstractProperty extends NamedModelElement {
+class TypedModelElement extends NamedModelElement {
   evaluateSegment(segment) {
     return this.$Type.target.evaluateSegment(segment);
   }
+  fromJSON(json) {
+    this.$Type = new NamespacePath(this, json.$Type);
+    super.fromJSON(json);
+  }
+}
+
+class AbstractProperty extends TypedModelElement {
   evaluationStart() {
     return this.parent;
   }
@@ -501,27 +554,19 @@ class AbstractProperty extends NamedModelElement {
 
 class Property extends AbstractProperty {
   fromJSON(json) {
+    if (!json.$Type) json = { ...json, $Type: "Edm.String" };
     super.fromJSON(json);
-    this.$Type = new NamespacePath(this, json.$Type || "Edm.String");
   }
   toJSON() {
-    const result = { ...this };
-    if (this.$Type.evaluate().toJSON() === "Edm.String") delete result.$Type;
-    return result;
+    const json = { ...this };
+    if (this.$Type.evaluate().toJSON() === "Edm.String") delete json.$Type;
+    return json;
   }
 }
 
-class NavigationProperty extends AbstractProperty {
-  fromJSON(json) {
-    super.fromJSON(json);
-    this.$Type = new NamespacePath(this, json.$Type);
-  }
-}
+class NavigationProperty extends AbstractProperty {}
 
 class EntityContainer extends NamedModelElement {
-  evaluateSegment(segment) {
-    return this.children[segment];
-  }
   fromJSON(json) {
     super.fromJSON(json, function (json) {
       if (json.$Type) return "EntitySetOrSingleton";
@@ -536,8 +581,8 @@ class EntitySetOrSingleton extends NamedModelElement {
     return this.$Type.target.evaluateSegment(segment);
   }
   fromJSON(json) {
-    super.fromJSON(json);
     this.$Type = new NamespacePath(this, json.$Type);
+    super.fromJSON(json);
     for (const prop in json.$NavigationPropertyBinding)
       new NavigationPropertyBinding(this, prop).fromJSON(
         json.$NavigationPropertyBinding,
@@ -558,7 +603,6 @@ class NavigationPropertyBinding extends NamedSubElement {
     return this.#entitySet;
   }
   fromJSON(json) {
-    // TODO: $NavigationPropertyBinding annotations
     this.#navigationProperty = new RelativePath(
       this,
       this.name,
@@ -585,6 +629,21 @@ class FunctionImport extends NamedModelElement {
     super.fromJSON(json);
   }
 }
+
+class TypeDefinition extends NamedModelElement {}
+
+class EnumType extends NamedModelElement {
+  fromJSON(json) {
+    super.fromJSON(json, "Member");
+  }
+  toJSON() {
+    return NamedValue.toJSONWithAnnotations(this, super.toJSON());
+  }
+}
+
+class Member extends NamedValue {}
+
+class Term extends Property {}
 
 function CSDLReviver(key, value) {
   if (key === "") {
@@ -619,6 +678,10 @@ const closure = (module.exports = {
   NavigationPropertyBinding,
   Function,
   FunctionImport,
+  TypeDefinition,
+  EnumType,
+  Member,
+  Term,
   CSDLReviver,
 });
 

--- a/lib/metamodel.js
+++ b/lib/metamodel.js
@@ -1,22 +1,22 @@
-const csdlDocuments = new Map();
-
 class ModelElement {
-  #children = {};
   #parent;
-  #targetingPaths = new Set();
-  #targetingSegments = new Set();
-  constructor(parent) {
-    this.#parent = parent;
-  }
-  get csdlDocument() {
-    return this.#parent.csdlDocument;
-  }
-  get children() {
-    return this.#children;
-  }
   get parent() {
     return this.#parent;
   }
+
+  #children = {};
+  get children() {
+    return this.#children;
+  }
+
+  constructor(parent) {
+    this.#parent = parent;
+  }
+
+  descendantOf(anc) {
+    return this.parent === anc || this.parent?.descendantOf?.(anc);
+  }
+
   path() {
     return (
       (this.parent instanceof Schema
@@ -29,148 +29,198 @@ class ModelElement {
   toString() {
     return this.constructor.name;
   }
-  /**
-   * @return {Set} set of #AbstractPath objects that target this model element
-   */
+
+  fromJSON(json, defaultKind) {
+    let hasAnnotations = false;
+    for (const member in json)
+      if (!this[member]) {
+        if (this.annotationFromJSON(json, member, json[member]))
+          hasAnnotations = true;
+        else if (!member.startsWith("$")) {
+          if (json[member] instanceof Array) {
+            this.children[member] = [];
+            for (const item of json[member]) {
+              const memberItem = new closure[item.$Kind](this);
+              memberItem.fromJSON(item);
+              this.children[member].push(memberItem);
+            }
+          } else {
+            const kind =
+              json[member].$Kind ||
+              (typeof defaultKind === "function"
+                ? defaultKind(json[member])
+                : defaultKind);
+            if (kind) new closure[kind](this, member).fromJSON(json[member]);
+          }
+        } else if (typeof json[member] !== "object")
+          this[member] = json[member];
+      }
+
+    if (hasAnnotations) this.csdlDocument.annotationTargets.push(this);
+  }
+
+  get csdlDocument() {
+    return this.parent.csdlDocument;
+  }
+
+  toJSON() {
+    const json = { ...this, ...this.children };
+
+    this.annotationsOfAnnotations(json, "");
+
+    return json;
+  }
+
+  toJSONWithAnnotations(sub, json) {
+    for (const member in this[sub])
+      for (const anno in this[sub][member])
+        if (anno.startsWith("@")) {
+          json[sub] ||= {};
+          json[sub][member + anno] = this[sub][member][anno];
+
+          this[sub][member][anno].annotationsOfAnnotations(
+            json[sub],
+            member + anno,
+          );
+        }
+    return json;
+  }
+
+  dynamicExprFromJSON(json) {
+    if (typeof json === "object") {
+      let value;
+      dynamic: {
+        for (const dynamicExpr in json)
+          switch (dynamicExpr) {
+            case "$Path":
+              value = new Path(this, json[dynamicExpr]);
+              break dynamic;
+
+            case "$And":
+            case "$Or":
+              value = new closure[dynamicExpr.substring(1)](this).fromJSON(
+                json[dynamicExpr],
+              );
+              break dynamic;
+          }
+
+        value = new (json instanceof Array ? Collection : Record)(this);
+      }
+      value.fromJSON(json);
+      return value;
+    } else return json;
+  }
+
+  #annotations = {};
+  get annotations() {
+    return this.#annotations;
+  }
+
+  finishAnnotations() {
+    this.#annotations = undefined;
+  }
+  annotationFromJSON(json, member, value) {
+    const m = member.match(/^([^@]*)(@.*)?@([^@]*?)(#([^@]*?))?$/);
+    if (m) {
+      const path = m[1] || "";
+      const anno = new Annotation(
+        this,
+        new RelativePath(this, path, this, "target"),
+        m[3],
+        m[5],
+      );
+      anno.fromJSON(value);
+      this.annotations[path] ||= {};
+      this.annotations[path][`${m[2] || ""}@${m[3]}${m[5] ? "#" + m[5] : ""}`] =
+        anno;
+      return true;
+    } else return false;
+  }
+
+  nestAnnotations(annos, member, anno) {
+    const termcast = member.replace(
+      /(?<=@).*?(?=#|$)/,
+
+      function (m) {
+        return this.csdlDocument.unalias(m);
+      }.bind(this),
+    );
+    this[termcast] = anno;
+    for (const mem in annos) {
+      const m = mem.replace(
+        /(?<=@).*?(?=#|@|$)/g,
+
+        function (m) {
+          return this.csdlDocument.unalias(m);
+        }.bind(this),
+      );
+      if (m.startsWith(termcast + "@"))
+        this[termcast].nestAnnotations(
+          annos,
+          m.substring(termcast.length),
+          annos[mem],
+        );
+    }
+  }
+
+  annotationsOfAnnotations(json, prefix) {
+    for (const member in this)
+      if (member.startsWith("@")) {
+        this[member].annotationsOfAnnotations(json, prefix + member);
+        if (prefix) json[prefix + member] = this[member];
+      }
+  }
+
+  evaluateSegment(segment) {
+    return this.children[segment.segment];
+  }
+
+  get host() {
+    return this.annotation?.host || this;
+  }
+
+  evaluationStart(anno) {
+    return this;
+  }
+
+  #targetingPaths = new Set();
   get targetingPaths() {
     return this.#targetingPaths;
   }
-  /**
-   * @return {Set} set of #Segment objects that are non-final in their path
-   * and target this model element
-   */
+
+  #targetingSegments = new Set();
   get targetingSegments() {
     return this.#targetingSegments;
   }
-  eval(path) {
-    return (
-      path.includes(".")
-        ? new NamespacePath(this, path)
-        : new RelativePath(this, path, this.evaluationStart())
-    ).evaluate(this);
-  }
-  evaluationStart() {
-    return this;
-  }
-  evaluate(path, offset = 0) {
-    let target = this;
-    for (let i = offset; i < path.segments.length; i++) {
-      target = path.segments[i].evaluate(target);
-      if (!target) throw new InvalidPathError(path);
-      if (i < path.segments.length - 1)
-        target.targetingSegments.add(path.segments[i]);
-    }
-    target.targetingPaths.add(path);
-    return target;
-  }
-  evaluateSegment(segment) {
-    return this.children[segment];
-  }
-  fromJSON(json, defaultKind) {
-    const annos = {};
-    for (const member in json) {
-      const m = member.match(/^(.*)@(.*?)(#(.*?))?$/);
-      if (m) {
-        const anno = new Annotation(
-          m[1] ? new RelativePath(this, m[1], this, "target").evaluate() : this,
-          m[2],
-          m[4],
-        );
-        anno.fromJSON(json[member]);
-        if (m[1]) {
-          annos[m[1]] ||= {};
-          annos[m[1]][anno.termcast] = anno;
-        } else this[member] = anno;
-      } else if (!member.startsWith("$")) {
-        if (json[member] instanceof Array) {
-          this.children[member] = [];
-          for (const item of json[member]) {
-            const memberItem = new closure[item.$Kind](this);
-            memberItem.fromJSON(item);
-            this.children[member].push(memberItem);
-          }
-        } else {
-          const kind =
-            json[member].$Kind ||
-            (typeof defaultKind === "function"
-              ? defaultKind(json[member])
-              : defaultKind);
-          if (kind) new closure[kind](this, member);
-          else this.children[member] = new ModelElement(this);
-          this.children[member].fromJSON(json[member]);
-        }
-      } else if (!this[member] && typeof json[member] !== "object")
-        this[member] = json[member];
-    }
-    for (const member in annos)
-      for (const a in annos[member]) {
-        const target = this[member] || this.children[member];
-        if (typeof target === "object") target[a] = annos[member][a];
-        else this[member + a] = annos[member][a];
+
+  isAnnotation(callback) {
+    for (const p of this.targetingPaths)
+      if (p.attribute === "$Path") {
+        const anno = p.parent.annotation;
+        if (anno && callback(anno)) return true;
       }
-  }
-  toJSON() {
-    return { ...this, ...this.children };
-  }
-}
-
-class NamedModelElement extends ModelElement {
-  #name;
-  get name() {
-    return this.#name;
-  }
-  constructor(parent, name) {
-    super(parent);
-    this.#name = name;
-    parent.children[name] = this;
-  }
-  toString() {
-    return this.name;
-  }
-}
-
-class NamedSubElement extends NamedModelElement {
-  constructor(parent, sub, name) {
-    super(parent, name);
-    parent[sub] ||= {};
-    parent[sub][name] = this;
-  }
-}
-
-class NamedValue extends NamedModelElement {
-  #value;
-  get value() {
-    return this.#value;
-  }
-  static toJSONWithAnnotations(modelElement, json) {
-    for (const member in modelElement.children)
-      for (const anno in modelElement.children[member])
-        if (anno.startsWith("@"))
-          json[member + anno] = modelElement.children[member][anno];
-    return json;
-  }
-  fromJSON(json) {
-    this.#value = json;
-  }
-  toJSON() {
-    return this.value;
   }
 }
 
 class CSDLDocument extends ModelElement {
-  #uri;
-  #paths = [];
-  #finish;
-  constructor(uri) {
-    super();
-    this.#uri = uri || "";
-  }
   get csdlDocument() {
     return this;
   }
-  get paths() {
-    return this.#paths;
+
+  fromJSON(json) {
+    if (json.$EntityContainer)
+      this.$EntityContainer = new QualifiedNamePath(
+        this,
+        json.$EntityContainer,
+        "$EntityContainer",
+      );
+
+    for (const uri in json.$Reference)
+      new Reference(this, uri).fromJSON(json.$Reference[uri]);
+
+    super.fromJSON(json, "Schema");
   }
+
   #findSchema(namespace, callback) {
     let result;
     for (const schema in this.children)
@@ -186,28 +236,70 @@ class CSDLDocument extends ModelElement {
       }
     return result;
   }
-  unalias(namespace) {
-    return this.#findSchema(namespace, (schema) => schema.name);
-  }
   byQualifiedName(namespace, name) {
     return this.#findSchema(namespace, (schema) => schema.children[name]);
   }
-  /** Await this before addressing #AbstractPath.target, #ModelElement.targetingPaths
-   * or #ModelElement.targetingSegments
-   */
+
+  #annotationTargets = [];
+  get annotationTargets() {
+    return this.#annotationTargets;
+  }
+
+  get(path) {
+    return new RelativePath(this, path, this).evaluate();
+  }
+
+  #uri;
+  #finish;
+
+  #finished;
+  get finished() {
+    return this.#finished;
+  }
+
+  #schemas;
+  get schemas() {
+    return this.#schemas;
+  }
+
+  constructor(uri, schemas) {
+    super();
+    this.#uri = uri || "";
+    this.#schemas = schemas;
+  }
   finish() {
     if (!this.#finish) {
+      this.#schemas ||= new CSDLDocument();
+      Object.assign(this.schemas.children, this.children);
+
       let finished;
       this.#finish = new Promise(function (resolve, reject) {
         finished = resolve;
       });
+
       const references = [];
       for (const uri in this.$Reference)
         references.push(this.$Reference[uri].resolve());
       Promise.all(references).then(
         async function (uris) {
-          for (const path of this.paths) path.target;
+          for (const target of this.annotationTargets) {
+            for (const path in target.annotations) {
+              const t = path ? target.children[path] : target;
+              for (const member in target.annotations[path])
+                if (!/@.*@/.test(member))
+                  t.nestAnnotations(
+                    target.annotations[path],
+                    member,
+                    target.annotations[path][member],
+                  );
+            }
+            target.finishAnnotations();
+          }
+          this.#annotationTargets = undefined;
+
+          for (const path of this.paths) path.evaluate();
           this.#paths = undefined;
+
           await Promise.all(
             uris
               .filter((uri) => uri > this.#uri)
@@ -218,132 +310,62 @@ class CSDLDocument extends ModelElement {
           finished();
         }.bind(this),
       );
+      this.#finished = true;
     }
     return this.#finish;
   }
-  fromJSON(json) {
-    super.fromJSON(json, "Schema");
-    for (const uri in json.$Reference)
-      new Reference(this, uri).fromJSON(json.$Reference[uri]);
+
+  #paths = [];
+  get paths() {
+    return this.#paths;
   }
+
+  unalias(qname) {
+    const i = qname.lastIndexOf(".");
+    const namespace = qname.substring(0, i);
+    const name = qname.substring(i + 1);
+    return this.#findSchema(namespace, (schema) => schema.name) + "." + name;
+  }
+
   toString() {
     return "";
   }
 }
 
-class Segment {
-  #path;
-  #segment;
-  #target;
-  constructor(path, segment) {
-    this.#path = path;
-    this.#segment = segment;
-  }
-  get target() {
-    if (!this.#target) this.#path.evaluate();
-    return this.#target;
-  }
-  set target(target) {
-    this.#target = target;
-  }
-  qualifiedName() {
-    const i = this.#segment.lastIndexOf(".");
-    return (
-      i !== -1 && {
-        namespace: this.#segment.substring(0, i),
-        name: this.#segment.substring(i + 1),
-      }
-    );
-  }
-  evaluate(modelElement) {
-    if (!modelElement.evaluateSegment) throw new InvalidPathError(this.#path);
-    return (this.#target = modelElement.evaluateSegment(this.#segment));
-  }
-  toJSON() {
-    return this.#segment;
-  }
-}
-
-class AbstractPath extends ModelElement {
-  #attribute;
-  #segments;
-  constructor(host, path, attribute) {
-    super(host);
-    this.#segments = path
-      .split("/")
-      .map((segment) => new Segment(this, segment));
-    this.#attribute = attribute;
-  }
-  get target() {
-    return this.#segments[this.#segments.length - 1].target;
-  }
-  get segments() {
-    return this.#segments;
-  }
-  get attribute() {
-    return this.#attribute;
-  }
-  toString() {
-    return this.attribute || super.toString();
-  }
-  toJSON() {
-    return this.segments.map((segment) => segment.toJSON()).join("/");
-  }
-}
-
-class NamespacePath extends AbstractPath {
-  constructor(host, path, attribute) {
-    super(host, path, attribute);
-    this.csdlDocument.paths?.unshift(this);
-  }
-  unalias() {
-    const { namespace, name } = this.segments[0].qualifiedName();
-    return this.csdlDocument.unalias(namespace) + "." + name;
-  }
-  evaluate() {
-    const { namespace, name } = this.segments[0].qualifiedName();
-    if (["Edm", "odata"].includes(namespace)) return this.segments[0];
-    let target = this.csdlDocument.byQualifiedName(namespace, name);
-    if (!target) throw new InvalidPathError(this);
-    // TODO: Address operation overloads
-    if (target instanceof Array)
-      target = target.some((t) => t.evaluate(this, 1));
-    else target = target.evaluate(this, 1);
-    return (this.segments[0].target = target);
-  }
-}
-
-class RelativePath extends AbstractPath {
-  #relativeTo;
-  constructor(host, path, relativeTo, attribute) {
-    super(host, path, attribute);
-    this.#relativeTo = relativeTo;
-    this.csdlDocument.paths?.push(this);
-  }
-  evaluate() {
-    const target = this.#relativeTo.evaluate(this);
-    if (!target) throw new InvalidPathError(this);
-    return target;
-  }
-}
-
-class InvalidPathError extends Error {
-  constructor(path) {
-    super("Invalid path " + path.toJSON());
-  }
+function CSDLReviver(key, value) {
+  if (key === "") {
+    const csdlDocument = new CSDLDocument();
+    csdlDocument.fromJSON(value);
+    return csdlDocument;
+  } else return value;
 }
 
 class Reference extends ModelElement {
   #uri;
+  get uri() {
+    return this.#uri;
+  }
+
   constructor(csdlDocument, uri) {
     super(csdlDocument);
     this.#uri = uri;
     csdlDocument.$Reference ||= {};
     csdlDocument.$Reference[uri] = this;
   }
-  get uri() {
-    return this.#uri;
+  toString() {
+    return "$Reference<" + this.uri + ">";
   }
+  fromJSON(json) {
+    if (json.$Include)
+      for (const include of json.$Include) new Include(this).fromJSON(include);
+
+    if (json.$IncludeAnnotations)
+      for (const include of json.$IncludeAnnotations)
+        new IncludeAnnotations(this).fromJSON(include);
+
+    super.fromJSON(json);
+  }
+
   async resolve() {
     let csdl = csdlDocuments.get(this.uri);
     if (!csdl)
@@ -351,7 +373,7 @@ class Reference extends ModelElement {
         this.uri,
         (csdl = new Promise(
           async function (resolve, reject) {
-            const csdl = new CSDLDocument(this.uri);
+            const csdl = new CSDLDocument(this.uri, this.csdlDocument.schemas);
             csdl.fromJSON(await (await fetch(this.uri)).json());
             resolve(csdl);
           }.bind(this),
@@ -361,18 +383,10 @@ class Reference extends ModelElement {
     if (this.$Include)
       for (const include of this.$Include)
         include.schema = csdl.children[include.$Namespace];
+    if (this.$IncludeAnnotations)
+      for (const include of this.$IncludeAnnotations)
+        include.schema = csdl.children[include.$TermNamespace];
     return this.uri;
-  }
-  fromJSON(json) {
-    super.fromJSON(json);
-    if (json.$Include)
-      for (const include of json.$Include) new Include(this).fromJSON(include);
-    if (json.$IncludeAnnotations)
-      for (const include of json.$IncludeAnnotations)
-        new IncludeAnnotations(this).fromJSON(include);
-  }
-  toString() {
-    return "$Reference<" + this.uri + ">";
   }
 }
 
@@ -390,15 +404,16 @@ class ListedModelElement extends ModelElement {
     return this.#list + "/" + this.#index;
   }
 }
-
 class Include extends ListedModelElement {
   #schema;
   get schema() {
     return this.#schema;
   }
+
   set schema(schema) {
     this.#schema = schema;
   }
+
   constructor(reference) {
     super(reference, "$Include");
   }
@@ -410,149 +425,173 @@ class IncludeAnnotations extends ListedModelElement {
   }
 }
 
-class Annotation extends ModelElement {
-  #term;
-  #qualifier;
-  #value;
-  constructor(target, term, qualifier) {
-    super(target);
-    this.#term = new NamespacePath(this, term, "term");
-    this.#qualifier = qualifier;
+class NamedModelElement extends ModelElement {
+  #name;
+  get name() {
+    return this.#name;
   }
-  get termcast() {
-    return (
-      "@" + this.#term.toJSON() + (this.#qualifier ? "#" + this.#qualifier : "")
-    );
+
+  constructor(parent, name) {
+    super(parent);
+    this.#name = name;
+    parent.children[name] = this;
+    this.$Kind = this.constructor.name;
   }
-  get value() {
-    return this.#value;
+  toString() {
+    return this.name;
   }
-  set value(value) {
-    this.#value = value;
-  }
-  evaluationStart() {
-    return this.parent.evaluationStart();
-  }
-  fromJSON(json) {
-    if (typeof json === "object") {
-      dynamic: {
-        for (const dynamicExpr in json)
-          switch (dynamicExpr) {
-            case "$Path":
-              this.value = new Path(
-                this,
-                json[dynamicExpr],
-                this.parent.evaluationStart(),
-              );
-              break dynamic;
-          }
-        this.value = new (json instanceof Array ? Collection : Record)(this);
-      }
-      this.value.fromJSON(json);
-    } else this.value = json;
-  }
-  toJSON() {
-    return this.value.toJSON?.() || this.value;
+}
+class Schema extends NamedModelElement {
+  constructor(csdlDocument, name) {
+    super(csdlDocument, name);
+    delete this.$Kind;
   }
 }
 
-class Schema extends NamedModelElement {}
+class AbstractPath extends ModelElement {
+  #segments;
+  get segments() {
+    return this.#segments;
+  }
 
-class Record extends ModelElement {
-  evaluationStart() {
-    return this.parent.evaluationStart();
+  set segments(segments) {
+    this.#segments = segments;
   }
-  fromJSON(json) {
-    super.fromJSON(json, "PropertyValue");
-  }
-}
 
-class Collection extends ModelElement {
-  #value;
-  get value() {
-    return this.#value;
+  #attribute;
+  get attribute() {
+    return this.#attribute;
   }
-  set value(value) {
-    this.#value = value;
-  }
-  evaluationStart() {
-    return this.parent.evaluationStart();
-  }
-  fromJSON(json) {
-    const value = [];
-    for (const item of json) {
-      Annotation.prototype.fromJSON.call(this, item);
-      value.push(this.value);
-    }
-    this.value = value;
-  }
-  toJSON() {
-    return this.value.map((item) =>
-      Annotation.prototype.toJSON.call(this, item),
-    );
-  }
-}
 
-class PropertyValue extends NamedModelElement {
-  #value;
-  get value() {
-    return this.#value;
-  }
-  set value(value) {
-    this.#value = value;
-  }
-  evaluationStart() {
-    return this.parent.evaluationStart();
-  }
-  fromJSON(json) {
-    Annotation.prototype.fromJSON.call(this, json);
-  }
-  toJSON(json) {
-    return Annotation.prototype.toJSON.call(this, json);
-  }
-}
-
-class Path extends ModelElement {
-  constructor(host, path) {
+  constructor(host, attribute) {
     super(host);
-    this.$Path = new RelativePath(this, path, host.evaluationStart(), "$Path");
+    this.#attribute = attribute;
+  }
+  toString() {
+    return this.attribute || super.toString();
+  }
+  toJSON() {
+    return this.segments.map((segment) => segment.toJSON()).join("/");
+  }
+
+  get target() {
+    return this.segments[this.segments.length - 1].target;
+  }
+
+  evaluateSegment(segment) {
+    return this.target.evaluateSegment(segment);
+  }
+}
+class QualifiedNamePath extends AbstractPath {
+  constructor(host, qname, attribute) {
+    super(host, attribute);
+    this.segments = [new QualifiedNameSegment(this, qname)];
+
+    this.csdlDocument.paths?.push(this);
+  }
+  evaluate() {
+    const target = this.segments[0].evaluateRelativeTo();
+
+    if (this.csdlDocument.paths) target.targetingPaths?.add(this);
+
+    return target;
+  }
+}
+
+class Segment {
+  #target;
+
+  #path;
+  get path() {
+    return this.#path;
+  }
+
+  #segment;
+  get segment() {
+    return this.#segment;
+  }
+
+  constructor(path, segment) {
+    this.#path = path;
+    this.#segment = segment;
+  }
+  get target() {
+    if (!this.#target) {
+      if (!this.path.csdlDocument.finished) return "CSDL document not finished";
+
+      this.path.evaluate();
+    }
+    return this.#target;
+  }
+  set target(target) {
+    this.#target = target;
+  }
+  toJSON() {
+    return this.#segment;
+  }
+}
+class QualifiedNameSegment extends Segment {
+  #namespace;
+  #name;
+  constructor(path, segment) {
+    super(path, segment);
+
+    const i = segment.lastIndexOf(".");
+    this.#namespace = segment.substring(0, i);
+    this.#name = segment.substring(i + 1);
+  }
+  evaluateRelativeTo(modelElement) {
+    if (["Edm", "odata", "System", "Transient"].includes(this.#namespace))
+      return this;
+    return (this.target = this.path.csdlDocument.byQualifiedName(
+      this.#namespace,
+      this.#name,
+    ));
   }
 }
 
 class ComplexType extends NamedModelElement {
-  evaluateSegment(segment) {
-    return (
-      super.evaluateSegment(segment) ||
-      this.$BaseType.target.evaluateSegment(segment)
-    );
+  #effectiveType;
+  get effectiveType() {
+    return (this.#effectiveType ||= this.computeEffectiveType());
   }
-  /**
-   * @return {ComplexType} structured type containing also the inherited properties
-   */
-  effectiveType() {
+  computeEffectiveType() {
     if (!this.$BaseType) return this;
-    const props = { ...this.$BaseType.effectiveType };
-    for (const prop in this.children)
-      if (prop in props) {
-        // TODO: Merge this.children[prop] into props[prop]
-      } else props[prop] = this.children[prop];
     const effectiveType = new this.constructor(
-      new ModelElement(this),
-      this.name,
+      new ModelElement(),
+      this.name + "<effective>",
     );
-    for (const prop in props) effectiveType.children[prop] = props[prop];
+    for (const prop in this.$BaseType.target.effectiveType.children)
+      effectiveType.children[prop] =
+        this.$BaseType.target.effectiveType.children[prop];
+    for (const prop in this.children)
+      if (prop in effectiveType.children) {
+        effectiveType.children[prop] = new this.children[prop].constructor(
+          effectiveType,
+          prop,
+        );
+        Object.assign(
+          effectiveType.children[prop],
+          this.$BaseType.target.effectiveType.children[prop],
+          this.children[prop],
+        );
+      } else effectiveType.children[prop] = this.children[prop];
     return effectiveType;
   }
   fromJSON(json) {
-    super.fromJSON(json, "Property");
     if (json.$BaseType)
-      this.$BaseType = new NamespacePath(this, json.$BaseType, "$BaseType");
+      this.$BaseType = new QualifiedNamePath(this, json.$BaseType, "$BaseType");
+
+    super.fromJSON(json, "Property");
+  }
+
+  evaluateSegment(segment) {
+    return this.effectiveType.children[segment.segment];
   }
 }
-
 class EntityType extends ComplexType {
-  effectiveType() {
-    const effectiveType = super.effectiveType();
+  computeEffectiveType() {
+    const effectiveType = super.computeEffectiveType();
     if (effectiveType !== this)
       for (let t = this; t; t = t.$BaseType?.target)
         if (t.$Key) {
@@ -562,85 +601,239 @@ class EntityType extends ComplexType {
     return effectiveType;
   }
   fromJSON(json) {
+    if (json.$Key)
+      for (const propRef of json.$Key) new PropertyRef(this).fromJSON(propRef);
     super.fromJSON(json);
-    if (json.$Key) {
-      this.$Key = new Key(this);
-      this.$Key.fromJSON(json.$Key);
-    }
   }
 }
 
-class Key extends ModelElement {
-  #entityType;
-  #propertyRefs = [];
-  constructor(entityType) {
-    super(entityType);
-    this.#entityType = entityType;
-  }
-  fromJSON(json) {
-    for (const prop of json) {
-      let propRef;
-      if (typeof prop === "string")
-        propRef = new PropertyRef(
-          this,
-          prop,
-          new RelativePath(this, prop, this.#entityType, "$Key"),
-        );
-      else
-        for (const name in prop)
-          propRef = new PropertyRef(
-            this,
-            name,
-            new RelativePath(this, prop[name], this.#entityType, "$Key"),
-            true,
-          );
-      this.#propertyRefs.push(propRef);
-    }
-  }
-  toJSON() {
-    return this.#propertyRefs;
-  }
-}
-
-class PropertyRef extends NamedModelElement {
+class PropertyRef extends ListedModelElement {
   #path;
   #alias;
-  constructor(key, name, path, alias) {
-    super(key, name);
-    this.#path = path;
-    this.#alias = alias;
+  constructor(entityType) {
+    super(entityType, "$Key");
   }
   get target() {
     return this.#path.target;
   }
+  fromJSON(json) {
+    if (typeof json === "string")
+      this.#path = new RelativePath(this, json, this.parent, "$Key");
+    else
+      for (const name in json) {
+        this.#alias = name;
+
+        this.#path = new RelativePath(this, json[name], this.parent, "$Key");
+      }
+  }
   toJSON() {
     if (this.#alias) {
       const propRef = {};
-      propRef[this.name] = this.#path;
+      propRef[this.#alias] = this.#path;
       return propRef;
-    } else return this.name;
+    } else return this.#path.toJSON();
   }
 }
 
 class TypedModelElement extends NamedModelElement {
+  fromJSON(json) {
+    this.$Type = new QualifiedNamePath(this, json.$Type, "$Type");
+
+    super.fromJSON(json);
+  }
+
   evaluateSegment(segment) {
-    return this.$Type.target.evaluateSegment(segment);
+    return this.$Type.evaluateSegment(segment);
+  }
+}
+class AbstractProperty extends TypedModelElement {
+  evaluationStart(anno) {
+    if (anno.descendantOf(this)) return this.parent;
+  }
+}
+class Property extends AbstractProperty {
+  constructor(parent, name) {
+    super(parent, name);
+    delete this.$Kind;
+  }
+
+  fromJSON(json) {
+    if (!json.$Type) json = { ...json, $Type: "Edm.String" };
+
+    super.fromJSON(json);
+  }
+  toJSON() {
+    const json = { ...super.toJSON() };
+    if (this.$Type.evaluate().toJSON() === "Edm.String") delete json.$Type;
+    return json;
+  }
+}
+
+class NavigationProperty extends AbstractProperty {
+  fromJSON(json) {
+    if (json.$Partner)
+      this.$Partner = new RelativePath(this, json.$Partner, this, "$Partner");
+
+    for (const ref in json.$ReferentialConstraint)
+      if (!ref.includes("@"))
+        new ReferentialConstraint(this, ref).fromJSON(
+          json.$ReferentialConstraint,
+        );
+
+    super.fromJSON(json);
+  }
+
+  toJSON() {
+    return this.toJSONWithAnnotations("$ReferentialConstraint", super.toJSON());
+  }
+}
+
+class NamedSubElement extends NamedModelElement {
+  constructor(parent, sub, name) {
+    super(parent, name);
+    parent[sub] ||= {};
+    parent[sub][name] = this;
+    delete this.$Kind;
+  }
+
+  fromJSON(json) {
+    let hasAnnotations = false;
+    for (const member in json)
+      if (member.startsWith(this.name + "@"))
+        if (
+          this.annotationFromJSON(
+            json,
+            member.substring(this.name.length),
+            json[member],
+          )
+        )
+          hasAnnotations = true;
+
+    if (hasAnnotations) this.csdlDocument.annotationTargets.push(this);
+  }
+}
+
+class ReferentialConstraint extends NamedSubElement {
+  #dependent;
+  get dependent() {
+    return this.#dependent;
+  }
+
+  set dependent(dependent) {
+    this.#dependent = dependent;
+  }
+
+  #principal;
+  get principal() {
+    return this.#principal;
+  }
+
+  set principal(principal) {
+    this.#principal = principal;
+  }
+
+  constructor(navigationProperty, prop) {
+    super(navigationProperty, "$ReferentialConstraint", prop);
   }
   fromJSON(json) {
-    this.$Type = new NamespacePath(this, json.$Type, "$Type");
+    this.dependent = new RelativePath(
+      this,
+      this.name,
+      this.parent.parent,
+      "$ReferentialConstraint.Dependent",
+    );
+    this.principal = new RelativePath(
+      this,
+      json[this.name],
+      this.parent,
+      "$ReferentialConstraint.Principal",
+    );
+    super.fromJSON(json);
+  }
+  toJSON() {
+    return this.principal.toJSON();
+  }
+}
+
+class EnumType extends NamedModelElement {
+  fromJSON(json) {
+    super.fromJSON(json, "Member");
+  }
+
+  toJSON() {
+    return NamedValue.toJSONWithAnnotations(this, super.toJSON());
+  }
+}
+
+class NamedValue extends NamedModelElement {
+  #value;
+  get value() {
+    return this.#value;
+  }
+
+  fromJSON(json) {
+    this.#value = json;
+  }
+  toJSON() {
+    return this.value;
+  }
+
+  static toJSONWithAnnotations(modelElement, json) {
+    for (const member in modelElement.children)
+      for (const anno in modelElement.children[member])
+        if (anno.startsWith("@"))
+          json[member + anno] = modelElement.children[member][anno];
+    return json;
+  }
+}
+class Member extends NamedValue {}
+
+class TypeDefinition extends NamedModelElement {
+  fromJSON(json) {
+    this.$UnderlyingType = new QualifiedNamePath(
+      this,
+      json.$UnderlyingType,
+      "$UnderlyingType",
+    );
+
     super.fromJSON(json);
   }
 }
 
-class AbstractProperty extends TypedModelElement {
-  evaluationStart() {
-    return this.parent;
+class Operation extends ModelElement {
+  constructor(parent) {
+    super(parent);
+    this.$Kind = this.constructor.name;
+  }
+  fromJSON(json) {
+    if (json.$ReturnType) {
+      this.$ReturnType = new ReturnType(this);
+      this.$ReturnType.fromJSON(json.$ReturnType);
+    }
+
+    if (json.$Parameter) {
+      for (const param of json.$Parameter) new Parameter(this).fromJSON(param);
+    }
+
+    super.fromJSON(json);
+  }
+
+  evaluateSegment(segment) {
+    return segment.segment === "$ReturnType"
+      ? this.$ReturnType
+      : this.$Parameters?.find?.((p) => p.name === segment.segment);
   }
 }
+class Action extends Operation {}
 
-class Property extends AbstractProperty {
+class Function extends Operation {}
+
+class ReturnType extends ModelElement {
   fromJSON(json) {
     if (!json.$Type) json = { ...json, $Type: "Edm.String" };
+
+    this.$Type = new QualifiedNamePath(this, json.$Type, "$Type");
+
     super.fromJSON(json);
   }
   toJSON() {
@@ -650,10 +843,29 @@ class Property extends AbstractProperty {
   }
 }
 
-class NavigationProperty extends AbstractProperty {}
+class Parameter extends ListedModelElement {
+  constructor(operation) {
+    super(operation, "$Parameter");
+  }
+  fromJSON(json) {
+    if (!json.$Type) json = { ...json, $Type: "Edm.String" };
+
+    this.$Type = new QualifiedNamePath(this, json.$Type, "$Type");
+
+    super.fromJSON(json);
+  }
+  toJSON() {
+    const json = { ...this };
+    if (this.$Type.evaluate().toJSON() === "Edm.String") delete json.$Type;
+    return json;
+  }
+}
 
 class EntityContainer extends NamedModelElement {
   fromJSON(json) {
+    if (json.$Extends)
+      this.$Extends = new QualifiedNamePath(this, json.$Extends, "$Extends");
+
     super.fromJSON(json, function (json) {
       if (json.$Type) return "EntitySetOrSingleton";
       if (json.$Function) return "FunctionImport";
@@ -662,86 +874,71 @@ class EntityContainer extends NamedModelElement {
   }
 }
 
-class EntitySetOrSingleton extends NamedModelElement {
-  evaluateSegment(segment) {
-    return this.$Type.target.evaluateSegment(segment);
+class EntitySetOrSingleton extends TypedModelElement {
+  constructor(parent, name) {
+    super(parent, name);
+    delete this.$Kind;
   }
+
   fromJSON(json) {
-    this.$Type = new NamespacePath(this, json.$Type, "$Type");
-    super.fromJSON(json);
     for (const prop in json.$NavigationPropertyBinding)
-      new NavigationPropertyBinding(this, prop).fromJSON(
-        json.$NavigationPropertyBinding,
-      );
+      if (!prop.includes("@"))
+        new NavigationPropertyBinding(this, prop).fromJSON(
+          json.$NavigationPropertyBinding,
+        );
+
+    super.fromJSON(json);
   }
 }
 
 class NavigationPropertyBinding extends NamedSubElement {
   #navigationProperty;
-  #entitySet;
-  constructor(entitySetOrSingleton, prop) {
-    super(entitySetOrSingleton, "$NavigationPropertyBinding", prop);
-  }
   get navigationProperty() {
     return this.#navigationProperty;
   }
+
+  set navigationProperty(navigationProperty) {
+    this.#navigationProperty = navigationProperty;
+  }
+  #entitySet;
   get entitySet() {
     return this.#entitySet;
   }
+
+  set entitySet(entitySet) {
+    this.#entitySet = entitySet;
+  }
+  constructor(entitySetOrSingleton, prop) {
+    super(entitySetOrSingleton, "$NavigationPropertyBinding", prop);
+  }
   fromJSON(json) {
-    this.#navigationProperty = new RelativePath(
+    this.navigationProperty = new RelativePath(
       this,
       this.name,
-      this.parent.$Type.target,
+      this.parent,
       "$NavigationPropertyBinding",
     );
-    this.#entitySet = new RelativePath(
+    this.entitySet = new RelativePath(
       this,
       json[this.name],
+      json[this.name].includes(".") ? this.csdlDocument : this.parent.parent,
       this.parent.parent,
       "$NavigationPropertyBinding.Target",
     );
+    super.fromJSON(json);
   }
   toJSON() {
     return this.entitySet.toJSON();
   }
 }
 
-class Operation extends ModelElement {
-  fromJSON(json) {
-    if (json.$Parameter) {
-      for (const param of json.$Parameter) new Parameter(this).fromJSON(param);
-    }
-    if (json.$ReturnType) {
-      this.$ReturnType = new ReturnType(this);
-      this.$ReturnType.fromJSON(json.$ReturnType);
-    }
-    super.fromJSON(json);
+class OperationImport extends NamedModelElement {
+  constructor(parent, name) {
+    super(parent, name);
+    delete this.$Kind;
   }
-}
 
-class Parameter extends ListedModelElement {
-  constructor(operation) {
-    super(operation, "$Parameter");
-  }
   fromJSON(json) {
-    this.$Type = new NamespacePath(this, json.$Type, "$Type");
-    super.fromJSON(json);
-  }
-}
-
-class ReturnType extends ModelElement {
-  fromJSON(json) {
-    this.$Type = new NamespacePath(this, json.$Type, "$Type");
-    super.fromJSON(json);
-  }
-}
-
-class Function extends Operation {}
-
-class FunctionImport extends NamedModelElement {
-  fromJSON(json) {
-    this.$Function = new NamespacePath(this, json.$Function, "$Function");
     if (json.$EntitySet)
       this.$EntitySet = new RelativePath(
         this,
@@ -752,88 +949,348 @@ class FunctionImport extends NamedModelElement {
     super.fromJSON(json);
   }
 }
-
-class Action extends Operation {}
-
-class ActionImport extends NamedModelElement {
+class ActionImport extends OperationImport {
   fromJSON(json) {
-    this.$Action = new NamespacePath(this, json.$Function, "$Action");
-    if (json.$EntitySet)
-      this.$EntitySet = new RelativePath(
-        this,
-        json.$EntitySet,
-        this.parent,
-        "$EntitySet",
-      );
+    this.$Action = new QualifiedNamePath(this, json.$Action, "$Action");
+
     super.fromJSON(json);
   }
 }
 
-class TypeDefinition extends NamedModelElement {}
-
-class EnumType extends NamedModelElement {
+class FunctionImport extends OperationImport {
   fromJSON(json) {
-    super.fromJSON(json, "Member");
-  }
-  toJSON() {
-    return NamedValue.toJSONWithAnnotations(this, super.toJSON());
+    this.$Function = new QualifiedNamePath(this, json.$Function, "$Function");
+
+    super.fromJSON(json);
   }
 }
-
-class Member extends NamedValue {}
 
 class Term extends Property {
   fromJSON(json) {
     if (json.$BaseTerm)
-      this.$BaseTerm = new NamespacePath(this, json.$BaseTerm, "$BaseTerm");
-    super.fromJSON(json, "Member");
+      this.$BaseTerm = new QualifiedNamePath(this, json.$BaseTerm, "$BaseTerm");
+
+    super.fromJSON(json);
   }
 }
 
-function CSDLReviver(key, value) {
-  if (key === "") {
-    const csdl = new CSDLDocument();
-    csdl.fromJSON(value);
-    csdl.finish();
-    return csdl;
-  } else return value;
+class Annotation extends ModelElement {
+  #target;
+  get target() {
+    return this.#target;
+  }
+
+  #term;
+  get term() {
+    return this.#term;
+  }
+
+  #qualifier;
+  get qualifier() {
+    return this.#qualifier;
+  }
+
+  #value;
+  get value() {
+    return this.#value;
+  }
+
+  set value(value) {
+    this.#value = value;
+  }
+
+  constructor(host, target, term, qualifier) {
+    super(host);
+    this.#target = target;
+    this.#term = new QualifiedNamePath(this, term, "term");
+    this.#qualifier = qualifier;
+  }
+  fromJSON(json) {
+    this.value = this.dynamicExprFromJSON(json);
+  }
+  toJSON() {
+    return this.value.toJSON?.() || this.value;
+  }
+
+  get host() {
+    return this.target.target.host;
+  }
+
+  get annotation() {
+    return this;
+  }
+}
+
+class RelativePath extends AbstractPath {
+  #relativeTo;
+  #absolute = "";
+  constructor(host, path, relativeTo, attribute) {
+    super(host, attribute);
+
+    if (path.startsWith("/")) {
+      this.#absolute = "/";
+      path = path.substring(1);
+      relativeTo = this.csdlDocument;
+    }
+
+    this.#relativeTo = relativeTo;
+    this.segments = path.split("/").map(
+      function (segment) {
+        switch (true) {
+          case segment.includes(".") && segment.includes("("):
+            return new OverloadSegment(this, segment);
+
+          case !segment.startsWith("@") && segment.includes("."):
+            return new QualifiedNameSegment(this, segment);
+
+          case segment.startsWith("@"):
+            return new TermCastSegment(this, segment);
+
+          default:
+            return new RelativeSegment(this, segment);
+        }
+      }.bind(this),
+    );
+
+    this.csdlDocument.paths?.push(this);
+  }
+  relativeTo() {
+    return this.#relativeTo;
+  }
+  toJSON() {
+    return this.#absolute + super.toJSON();
+  }
+
+  evaluate() {
+    let target = this.relativeTo();
+    for (let i = 0; i < this.segments.length; i++) {
+      target = this.segments[i].target =
+        this.segments[i].evaluateRelativeTo(target);
+
+      if (!target) throw new InvalidPathError(this);
+      if (this.csdlDocument.paths && i < this.segments.length - 1)
+        target.targetingSegments.add(this.segments[i]);
+    }
+
+    if (this.csdlDocument.paths) target.targetingPaths?.add(this);
+
+    return target;
+  }
+}
+class TermCastSegment extends Segment {
+  evaluateRelativeTo(modelElement) {
+    const termcast = this.segment.replace(
+      /(?<=@).*?(?=#|$)/,
+
+      function (m) {
+        return this.path.csdlDocument.unalias(m);
+      }.bind(this),
+    );
+    return modelElement[termcast];
+  }
+}
+
+class RelativeSegment extends Segment {
+  evaluateRelativeTo(modelElement) {
+    return this.segment ? modelElement.evaluateSegment(this) : modelElement;
+  }
+}
+
+const csdlDocuments = new Map();
+
+class InvalidPathError extends Error {
+  constructor(path) {
+    super("Invalid path " + path.toJSON());
+  }
+}
+
+class ValuePath extends RelativePath {
+  constructor(pathExpression, path) {
+    super(pathExpression, path, undefined, "$Path");
+  }
+  relativeTo() {
+    const anno = this.parent.annotation;
+    return anno.host.evaluationStart(anno);
+  }
+}
+class PathExpression extends ModelElement {
+  constructor(parent, path) {
+    super(parent);
+    this.$Path = new ValuePath(this, path);
+  }
+
+  get annotation() {
+    return this.parent.annotation;
+  }
+}
+
+class ModelElementPathExpression extends PathExpression {
+  toJSON() {
+    return this.$Path.toJSON();
+  }
+}
+class AnnotationPath extends ModelElementPathExpression {}
+
+class ModelElementPath extends ModelElementPathExpression {}
+
+class NavigationPropertyPath extends ModelElementPathExpression {}
+
+class PropertyPath extends ModelElementPathExpression {}
+
+class Path extends PathExpression {}
+
+class BinaryExpression extends ModelElement {
+  #left;
+  get left() {
+    return this.#left;
+  }
+
+  #right;
+  get right() {
+    return this.#right;
+  }
+
+  get annotation() {
+    return this.parent.annotation;
+  }
+
+  fromJSON(json) {
+    this.#left = this.dynamicExprFromJSON(json[0]);
+    this.#right = this.dynamicExprFromJSON(json[1]);
+  }
+  toJSON() {
+    return [this.#left, this.#right];
+  }
+}
+
+class And extends BinaryExpression {}
+class Or extends BinaryExpression {}
+
+class Collection extends ModelElement {
+  #value;
+  get value() {
+    return this.#value;
+  }
+
+  set value(value) {
+    this.#value = value;
+  }
+
+  get annotation() {
+    return this.parent.annotation;
+  }
+
+  fromJSON(json) {
+    this.value = json.map((item) => this.dynamicExprFromJSON(item));
+  }
+  toJSON() {
+    return this.value.map((item) => item.toJSON?.() || item);
+  }
+}
+
+class Record extends ModelElement {
+  get annotation() {
+    return this.parent.annotation;
+  }
+
+  fromJSON(json) {
+    super.fromJSON(json, "PropertyValue");
+  }
+}
+class PropertyValue extends NamedModelElement {
+  #value;
+  get value() {
+    return this.#value;
+  }
+
+  set value(value) {
+    this.#value = value;
+  }
+
+  get annotation() {
+    return this.parent.annotation;
+  }
+
+  fromJSON(json) {
+    Annotation.prototype.fromJSON.call(this, json);
+  }
+  toJSON() {
+    return Annotation.prototype.toJSON.call(this.value);
+  }
 }
 
 const closure = (module.exports = {
-  InvalidPathError,
-  RelativePath,
-  NamespacePath,
   CSDLDocument,
+  CSDLReviver,
+
   Reference,
+
   Include,
+
   IncludeAnnotations,
+
   Schema,
-  Annotation,
-  Record,
-  Collection,
-  PropertyValue,
+
+  QualifiedNamePath,
+
   ComplexType,
   EntityType,
-  Key,
-  PropertyRef,
-  Property,
-  NavigationProperty,
-  EntityContainer,
-  EntitySetOrSingleton,
-  NavigationPropertyBinding,
-  Function,
-  FunctionImport,
-  Action,
-  ActionImport,
-  TypeDefinition,
-  EnumType,
-  Member,
-  Term,
-  CSDLReviver,
-});
 
-debugger;
-global.csdl = JSON.parse(
-  require("fs").readFileSync(__dirname + "/../examples/csdl-16.1.json"),
-  CSDLReviver,
-);
+  PropertyRef,
+
+  Property,
+
+  NavigationProperty,
+
+  ReferentialConstraint,
+
+  EnumType,
+
+  Member,
+
+  TypeDefinition,
+
+  Action,
+
+  Function,
+
+  ReturnType,
+
+  Parameter,
+
+  EntityContainer,
+
+  EntitySetOrSingleton,
+
+  NavigationPropertyBinding,
+
+  ActionImport,
+
+  FunctionImport,
+
+  Term,
+
+  Annotation,
+
+  RelativePath,
+
+  InvalidPathError,
+
+  AnnotationPath,
+
+  ModelElementPath,
+
+  NavigationPropertyPath,
+
+  PropertyPath,
+
+  Path,
+
+  And,
+  Or,
+
+  Collection,
+
+  Record,
+  PropertyValue,
+});

--- a/lib/metamodel.js
+++ b/lib/metamodel.js
@@ -42,6 +42,16 @@ class ModelElement {
   get targetingSegments() {
     return this.#targetingSegments;
   }
+  eval(path) {
+    return (
+      path.includes(".")
+        ? new NamespacePath(this, path)
+        : new RelativePath(this, path, this.evaluationStart())
+    ).evaluate(this);
+  }
+  evaluationStart() {
+    return this;
+  }
   evaluate(path, offset = 0) {
     let target = this;
     for (let i = offset; i < path.segments.length; i++) {
@@ -53,13 +63,16 @@ class ModelElement {
     target.targetingPaths.add(path);
     return target;
   }
+  evaluateSegment(segment) {
+    return this.children[segment];
+  }
   fromJSON(json, defaultKind) {
     const annos = {};
     for (const member in json) {
       const m = member.match(/^(.*)@(.*?)(#(.*?))?$/);
       if (m) {
         const anno = new Annotation(
-          m[1] ? new RelativePath(this, m[1], this).evaluate() : this,
+          m[1] ? new RelativePath(this, m[1], this, "target").evaluate() : this,
           m[2],
           m[4],
         );
@@ -105,9 +118,6 @@ class NamedModelElement extends ModelElement {
   #name;
   get name() {
     return this.#name;
-  }
-  evaluateSegment(segment) {
-    return this.children[segment];
   }
   constructor(parent, name) {
     super(parent);
@@ -161,32 +171,26 @@ class CSDLDocument extends ModelElement {
   get paths() {
     return this.#paths;
   }
-  unalias(namespace) {
+  #findSchema(namespace, callback) {
+    let result;
     for (const schema in this.children)
       if ([this.children[schema].$Alias, schema].includes(namespace))
-        return schema;
-    for (const uri in this.$Reference)
-      for (const include of this.$Reference[uri].$Include)
-        if ([include.$Alias, include.$Namespace].includes(namespace))
-          return include.$Namespace;
-  }
-  byQualifiedName(namespace, name) {
-    let target;
-    for (const schema in this.children)
-      if ([this.children[schema].$Alias, schema].includes(namespace)) {
-        target = this.children[schema].children[name];
-        break;
-      }
-    if (!target)
+        result = callback(this.children[schema]);
+    if (!result)
       reference: {
         for (const uri in this.$Reference)
           for (const include of this.$Reference[uri].$Include)
-            if ([include.$Alias, include.$Namespace].includes(namespace)) {
-              target = include.schema.children[name];
-              if (target) break reference;
-            }
+            if ([include.$Alias, include.$Namespace].includes(namespace))
+              result = callback(include.schema);
+        if (result) break reference;
       }
-    return target;
+    return result;
+  }
+  unalias(namespace) {
+    return this.#findSchema(namespace, (schema) => schema.name);
+  }
+  byQualifiedName(namespace, name) {
+    return this.#findSchema(namespace, (schema) => schema.children[name]);
   }
   /** Await this before addressing #AbstractPath.target, #ModelElement.targetingPaths
    * or #ModelElement.targetingSegments
@@ -455,6 +459,9 @@ class Annotation extends ModelElement {
 class Schema extends NamedModelElement {}
 
 class Record extends ModelElement {
+  evaluationStart() {
+    return this.parent.evaluationStart();
+  }
   fromJSON(json) {
     super.fromJSON(json, "PropertyValue");
   }
@@ -467,6 +474,9 @@ class Collection extends ModelElement {
   }
   set value(value) {
     this.#value = value;
+  }
+  evaluationStart() {
+    return this.parent.evaluationStart();
   }
   fromJSON(json) {
     const value = [];
@@ -491,6 +501,9 @@ class PropertyValue extends NamedModelElement {
   set value(value) {
     this.#value = value;
   }
+  evaluationStart() {
+    return this.parent.evaluationStart();
+  }
   fromJSON(json) {
     Annotation.prototype.fromJSON.call(this, json);
   }
@@ -502,7 +515,7 @@ class PropertyValue extends NamedModelElement {
 class Path extends ModelElement {
   constructor(host, path) {
     super(host);
-    this.$Path = new RelativePath(this, path, host.evaluationStart());
+    this.$Path = new RelativePath(this, path, host.evaluationStart(), "$Path");
   }
 }
 
@@ -571,14 +584,14 @@ class Key extends ModelElement {
         propRef = new PropertyRef(
           this,
           prop,
-          new RelativePath(this, prop, this.#entityType),
+          new RelativePath(this, prop, this.#entityType, "$Key"),
         );
       else
         for (const name in prop)
           propRef = new PropertyRef(
             this,
             name,
-            new RelativePath(this, prop[name], this.#entityType),
+            new RelativePath(this, prop[name], this.#entityType, "$Key"),
             true,
           );
       this.#propertyRefs.push(propRef);
@@ -680,13 +693,13 @@ class NavigationPropertyBinding extends NamedSubElement {
       this,
       this.name,
       this.parent.$Type.target,
-      "navigationProperty",
+      "$NavigationPropertyBinding",
     );
     this.#entitySet = new RelativePath(
       this,
       json[this.name],
       this.parent.parent,
-      "navigationPropertyBindingTarget",
+      "$NavigationPropertyBinding.Target",
     );
   }
   toJSON() {

--- a/lib/metamodel.js
+++ b/lib/metamodel.js
@@ -17,6 +17,18 @@ class ModelElement {
   get parent() {
     return this.#parent;
   }
+  path() {
+    return (
+      (this.parent instanceof Schema
+        ? this.parent.path() + "."
+        : this.parent
+          ? this.parent.path() + "/"
+          : "") + this.toString()
+    );
+  }
+  toString() {
+    return this.constructor.name;
+  }
   /**
    * @return {Set} set of #AbstractPath objects that target this model element
    */
@@ -54,7 +66,7 @@ class ModelElement {
         anno.fromJSON(json[member]);
         if (m[1]) {
           annos[m[1]] ||= {};
-          annos[m[1]][m[2] + (m[3] || "")] = anno;
+          annos[m[1]][anno.termcast] = anno;
         } else this[member] = anno;
       } else if (!member.startsWith("$")) {
         if (json[member] instanceof Array) {
@@ -80,8 +92,8 @@ class ModelElement {
     for (const member in annos)
       for (const a in annos[member]) {
         const target = this[member] || this.children[member];
-        if (typeof target === "object") target["@" + a] = annos[member][a];
-        else this[member + "@" + a] = annos[member][a];
+        if (typeof target === "object") target[a] = annos[member][a];
+        else this[member + a] = annos[member][a];
       }
   }
   toJSON() {
@@ -101,6 +113,9 @@ class NamedModelElement extends ModelElement {
     super(parent);
     this.#name = name;
     parent.children[name] = this;
+  }
+  toString() {
+    return this.name;
   }
 }
 
@@ -146,15 +161,19 @@ class CSDLDocument extends ModelElement {
   get paths() {
     return this.#paths;
   }
+  unalias(namespace) {
+    for (const schema in this.children)
+      if ([this.children[schema].$Alias, schema].includes(namespace))
+        return schema;
+    for (const uri in this.$Reference)
+      for (const include of this.$Reference[uri].$Include)
+        if ([include.$Alias, include.$Namespace].includes(namespace))
+          return include.$Namespace;
+  }
   byQualifiedName(namespace, name) {
     let target;
     for (const schema in this.children)
-      if (
-        !schema.startsWith("$") &&
-        [this.children[schema].$Alias, this.children[schema].name].includes(
-          namespace,
-        )
-      ) {
+      if ([this.children[schema].$Alias, schema].includes(namespace)) {
         target = this.children[schema].children[name];
         break;
       }
@@ -203,6 +222,9 @@ class CSDLDocument extends ModelElement {
     for (const uri in json.$Reference)
       new Reference(this, uri).fromJSON(json.$Reference[uri]);
   }
+  toString() {
+    return "";
+  }
 }
 
 class Segment {
@@ -239,12 +261,14 @@ class Segment {
 }
 
 class AbstractPath extends ModelElement {
+  #attribute;
   #segments;
-  constructor(host, path) {
+  constructor(host, path, attribute) {
     super(host);
     this.#segments = path
       .split("/")
       .map((segment) => new Segment(this, segment));
+    this.#attribute = attribute;
   }
   get target() {
     return this.#segments[this.#segments.length - 1].target;
@@ -252,15 +276,25 @@ class AbstractPath extends ModelElement {
   get segments() {
     return this.#segments;
   }
+  get attribute() {
+    return this.#attribute;
+  }
+  toString() {
+    return this.attribute || super.toString();
+  }
   toJSON() {
     return this.segments.map((segment) => segment.toJSON()).join("/");
   }
 }
 
 class NamespacePath extends AbstractPath {
-  constructor(host, path) {
-    super(host, path);
+  constructor(host, path, attribute) {
+    super(host, path, attribute);
     this.csdlDocument.paths?.unshift(this);
+  }
+  unalias() {
+    const { namespace, name } = this.segments[0].qualifiedName();
+    return this.csdlDocument.unalias(namespace) + "." + name;
   }
   evaluate() {
     const { namespace, name } = this.segments[0].qualifiedName();
@@ -277,8 +311,8 @@ class NamespacePath extends AbstractPath {
 
 class RelativePath extends AbstractPath {
   #relativeTo;
-  constructor(host, path, relativeTo) {
-    super(host, path);
+  constructor(host, path, relativeTo, attribute) {
+    super(host, path, attribute);
     this.#relativeTo = relativeTo;
     this.csdlDocument.paths?.push(this);
   }
@@ -333,13 +367,23 @@ class Reference extends ModelElement {
       for (const include of json.$IncludeAnnotations)
         new IncludeAnnotations(this).fromJSON(include);
   }
+  toString() {
+    return "$Reference<" + this.uri + ">";
+  }
 }
 
 class ListedModelElement extends ModelElement {
+  #list;
+  #index;
   constructor(parent, list) {
     super(parent);
     parent[list] ||= [];
     parent[list].push(this);
+    this.#list = list;
+    this.#index = parent[list].length - 1;
+  }
+  toString() {
+    return this.#list + "/" + this.#index;
   }
 }
 
@@ -368,11 +412,13 @@ class Annotation extends ModelElement {
   #value;
   constructor(target, term, qualifier) {
     super(target);
-    this.#term = new NamespacePath(this, term);
+    this.#term = new NamespacePath(this, term, "term");
     this.#qualifier = qualifier;
   }
-  get term() {
-    return this.#term;
+  get termcast() {
+    return (
+      "@" + this.#term.toJSON() + (this.#qualifier ? "#" + this.#qualifier : "")
+    );
   }
   get value() {
     return this.#value;
@@ -487,7 +533,7 @@ class ComplexType extends NamedModelElement {
   fromJSON(json) {
     super.fromJSON(json, "Property");
     if (json.$BaseType)
-      this.$BaseType = new NamespacePath(this, json.$BaseType);
+      this.$BaseType = new NamespacePath(this, json.$BaseType, "$BaseType");
   }
 }
 
@@ -568,7 +614,7 @@ class TypedModelElement extends NamedModelElement {
     return this.$Type.target.evaluateSegment(segment);
   }
   fromJSON(json) {
-    this.$Type = new NamespacePath(this, json.$Type);
+    this.$Type = new NamespacePath(this, json.$Type, "$Type");
     super.fromJSON(json);
   }
 }
@@ -608,7 +654,7 @@ class EntitySetOrSingleton extends NamedModelElement {
     return this.$Type.target.evaluateSegment(segment);
   }
   fromJSON(json) {
-    this.$Type = new NamespacePath(this, json.$Type);
+    this.$Type = new NamespacePath(this, json.$Type, "$Type");
     super.fromJSON(json);
     for (const prop in json.$NavigationPropertyBinding)
       new NavigationPropertyBinding(this, prop).fromJSON(
@@ -634,11 +680,13 @@ class NavigationPropertyBinding extends NamedSubElement {
       this,
       this.name,
       this.parent.$Type.target,
+      "navigationProperty",
     );
     this.#entitySet = new RelativePath(
       this,
       json[this.name],
       this.parent.parent,
+      "navigationPropertyBindingTarget",
     );
   }
   toJSON() {
@@ -664,14 +712,14 @@ class Parameter extends ListedModelElement {
     super(operation, "$Parameter");
   }
   fromJSON(json) {
-    this.$Type = new NamespacePath(this, json.$Type);
+    this.$Type = new NamespacePath(this, json.$Type, "$Type");
     super.fromJSON(json);
   }
 }
 
 class ReturnType extends ModelElement {
   fromJSON(json) {
-    this.$Type = new NamespacePath(this, json.$Type);
+    this.$Type = new NamespacePath(this, json.$Type, "$Type");
     super.fromJSON(json);
   }
 }
@@ -680,9 +728,30 @@ class Function extends Operation {}
 
 class FunctionImport extends NamedModelElement {
   fromJSON(json) {
-    this.$Function = new NamespacePath(this, json.$Function);
+    this.$Function = new NamespacePath(this, json.$Function, "$Function");
     if (json.$EntitySet)
-      this.$EntitySet = new RelativePath(this, json.$EntitySet, this.parent);
+      this.$EntitySet = new RelativePath(
+        this,
+        json.$EntitySet,
+        this.parent,
+        "$EntitySet",
+      );
+    super.fromJSON(json);
+  }
+}
+
+class Action extends Operation {}
+
+class ActionImport extends NamedModelElement {
+  fromJSON(json) {
+    this.$Action = new NamespacePath(this, json.$Function, "$Action");
+    if (json.$EntitySet)
+      this.$EntitySet = new RelativePath(
+        this,
+        json.$EntitySet,
+        this.parent,
+        "$EntitySet",
+      );
     super.fromJSON(json);
   }
 }
@@ -700,7 +769,13 @@ class EnumType extends NamedModelElement {
 
 class Member extends NamedValue {}
 
-class Term extends Property {}
+class Term extends Property {
+  fromJSON(json) {
+    if (json.$BaseTerm)
+      this.$BaseTerm = new NamespacePath(this, json.$BaseTerm, "$BaseTerm");
+    super.fromJSON(json, "Member");
+  }
+}
 
 function CSDLReviver(key, value) {
   if (key === "") {
@@ -735,6 +810,8 @@ const closure = (module.exports = {
   NavigationPropertyBinding,
   Function,
   FunctionImport,
+  Action,
+  ActionImport,
   TypeDefinition,
   EnumType,
   Member,

--- a/lib/metamodel.js
+++ b/lib/metamodel.js
@@ -1,0 +1,601 @@
+class ModelElement {
+  #children = {};
+  #parent;
+  #targetingPaths = new Set();
+  constructor(parent) {
+    this.#parent = parent;
+  }
+  get csdlDocument() {
+    return this.#parent.csdlDocument;
+  }
+  get children() {
+    return this.#children;
+  }
+  get parent() {
+    return this.#parent;
+  }
+  addChild(name, value) {
+    this.children[name] = value;
+    if (this[name] === undefined)
+      Object.defineProperty(this, name, {
+        get: () => this.children[name],
+      });
+  }
+  /**
+   * @return {Set} set of #Path objects targeting this model element
+   */
+  get targetingPaths() {
+    return this.#targetingPaths;
+  }
+  evaluate(path, offset = 0) {
+    let target = this;
+    for (let i = offset; target && i < path.segments.length; i++)
+      target = path.segments[i].evaluate(target);
+    if (!target) throw new InvalidPathError(path);
+    target.targetingPaths.add(path);
+    return target;
+  }
+  fromJSON(json, defaultKind) {
+    for (const member in json) {
+      const m = member.match(/^(.*)@(.*?)\.(.*?)(#(.*?))?$/);
+      if (m) {
+        this[member] = new Annotation(
+          m[1] ? new RelativePath(this, m[1], this).evaluate() : this,
+          m[2],
+          m[3],
+          m[5],
+        );
+        this[member].fromJSON(json[member]);
+      } else if (!member.startsWith("$")) {
+        if (json[member] instanceof Array) {
+          this.addChild(member, []);
+          for (const item of json[member]) {
+            const memberItem = new closure[item.$Kind](this);
+            memberItem.fromJSON(item);
+            this.children[member].push(memberItem);
+          }
+        } else {
+          const kind =
+            json[member].$Kind ||
+            (typeof defaultKind === "function"
+              ? defaultKind(json[member])
+              : defaultKind);
+          if (kind) new closure[kind](this, member);
+          else this.addChild(member, new ModelElement(this));
+          this.children[member].fromJSON(json[member]);
+        }
+      } else if (!this[member] && typeof json[member] !== "object")
+        this[member] = json[member];
+    }
+  }
+  toJSON() {
+    return { ...this, ...this.children };
+  }
+}
+
+class NamedModelElement extends ModelElement {
+  #name;
+  get name() {
+    return this.#name;
+  }
+  constructor(parent, name) {
+    super(parent);
+    this.#name = name;
+    parent.addChild(name, this);
+  }
+}
+
+class NamedSubElement extends NamedModelElement {
+  constructor(parent, sub, name) {
+    super(parent, name);
+    parent[sub] ||= {};
+    parent[sub][name] = this;
+  }
+}
+
+class CSDLDocument extends ModelElement {
+  #paths = [];
+  get csdlDocument() {
+    return this;
+  }
+  get paths() {
+    return this.#paths;
+  }
+  finish() {
+    for (const path of this.paths) path.target;
+    this.#paths = undefined;
+  }
+  fromJSON(json) {
+    super.fromJSON(json, "Schema");
+    for (const uri in json.$Reference)
+      new Reference(this, uri).fromJSON(json.$Reference[uri]);
+  }
+}
+
+class Segment {
+  #path;
+  #segment;
+  #target;
+  constructor(path, segment) {
+    this.#path = path;
+    this.#segment = segment;
+  }
+  get target() {
+    if (!this.#target) this.#path.evaluate();
+    return this.#target;
+  }
+  set target(target) {
+    this.#target = target;
+  }
+  qualifiedName() {
+    const i = this.#segment.lastIndexOf(".");
+    return (
+      i !== -1 && {
+        namespace: this.#segment.substring(0, i),
+        name: this.#segment.substring(i + 1),
+      }
+    );
+  }
+  evaluate(modelElement) {
+    return (this.#target = modelElement.evaluateSegment(this.#segment));
+  }
+  toJSON() {
+    return this.#segment;
+  }
+}
+
+class AbstractPath extends ModelElement {
+  #segments;
+  constructor(host, path) {
+    super(host);
+    this.#segments = path
+      .split("/")
+      .map((segment) => new Segment(this, segment));
+  }
+  get target() {
+    return this.#segments[this.#segments.length - 1].target;
+  }
+  get segments() {
+    return this.#segments;
+  }
+  toJSON() {
+    return this.segments.map((segment) => segment.toJSON()).join("/");
+  }
+}
+
+class NamespacePath extends AbstractPath {
+  constructor(host, path) {
+    super(host, path);
+    this.csdlDocument.paths?.unshift(this);
+  }
+  evaluate() {
+    const { namespace, name } = this.segments[0].qualifiedName();
+    if (namespace === "Edm") return this.segments[0];
+    let target;
+    for (const schema in this.csdlDocument.children)
+      if (
+        !schema.startsWith("$") &&
+        (this.csdlDocument.children[schema].$Alias === namespace ||
+          this.csdlDocument.children[schema].namespace === namespace)
+      ) {
+        target = this.csdlDocument.children[schema].children[name];
+        if (target instanceof Array)
+          target = target.some((t) => t.evaluate(this, 1));
+        else target = target.evaluate(this, 1);
+        break;
+      }
+    if (!target) throw new InvalidPathError(this);
+    return (this.segments[0].target = target);
+  }
+}
+
+class RelativePath extends AbstractPath {
+  #relativeTo;
+  constructor(host, path, relativeTo) {
+    super(host, path);
+    this.#relativeTo = relativeTo;
+    this.csdlDocument.paths?.push(this);
+  }
+  evaluate() {
+    const target = this.#relativeTo.evaluate(this);
+    if (!target) throw new InvalidPathError(this);
+    return target;
+  }
+}
+
+class InvalidPathError extends Error {
+  constructor(path) {
+    super("Invalid path " + path.toJSON());
+  }
+}
+
+class Reference extends ModelElement {
+  #uri;
+  constructor(csdlDocument, uri) {
+    super(csdlDocument);
+    csdlDocument.$Reference ||= {};
+    csdlDocument.$Reference[uri] = this;
+  }
+  get uri() {
+    return this.#uri;
+  }
+  fromJSON(json) {
+    super.fromJSON(json);
+    if (json.$Include)
+      for (const include of json.$Include) new Include(this).fromJSON(include);
+    if (json.$IncludeAnnotations)
+      for (const include of json.$IncludeAnnotations)
+        new IncludeAnnotations(this).fromJSON(include);
+  }
+}
+
+class Include extends ModelElement {
+  constructor(reference) {
+    super(reference);
+    if (!reference.$Include) reference.$Include = [];
+    reference.$Include.push(this);
+  }
+}
+
+class IncludeAnnotations extends ModelElement {
+  constructor(reference) {
+    super(reference);
+    if (!reference.$IncludeAnnotations) reference.$IncludeAnnotations = [];
+    reference.$IncludeAnnotations.push(this);
+  }
+}
+
+class Namespaced extends ModelElement {
+  #namespace;
+  constructor(csdlDocument, namespace) {
+    super(csdlDocument);
+    this.#namespace = namespace;
+  }
+  #include() {
+    for (const schema in this.csdlDocument.children)
+      if (
+        !schema.startsWith("$") &&
+        (this.#namespace === this.csdlDocument.children[schema].$Alias ||
+          this.#namespace === schema)
+      )
+        return { namespace: this.csdlDocument.children[schema].#namespace };
+    for (const url in this.csdlDocument.$Reference) {
+      if (this.csdlDocument.$Reference[url].$Include)
+        for (const include of this.csdlDocument.$Reference[url].$Include)
+          if (
+            this.#namespace === include.$Alias ||
+            this.#namespace === include.$Namespace
+          )
+            return { url, namespace: include.$Namespace };
+    }
+  }
+  get namespace() {
+    return this.#include().namespace;
+  }
+  get namespaceURL() {
+    return this.#include().url;
+  }
+}
+
+class Annotation extends Namespaced {
+  #target;
+  #term;
+  #qualifier;
+  #value;
+  constructor(target, namespace, term, qualifier) {
+    super(target, namespace);
+    this.#target = target;
+    this.#term = term;
+    this.#qualifier = qualifier;
+  }
+  get value() {
+    return this.#value;
+  }
+  set value(value) {
+    this.#value = value;
+  }
+  evaluationStart() {
+    return this.#target.evaluationStart();
+  }
+  fromJSON(json) {
+    if (typeof json === "object") {
+      dynamic: {
+        for (const dynamicExpr in json)
+          switch (dynamicExpr) {
+            case "$Path":
+              this.value = new Path(
+                this,
+                json[dynamicExpr],
+                this.#target.evaluationStart(),
+              );
+              break dynamic;
+          }
+        this.value = new (json instanceof Array ? Collection : Record)(this);
+      }
+      this.value.fromJSON(json);
+    } else this.value = json;
+  }
+  toJSON() {
+    return this.value.toJSON?.() || this.value;
+  }
+}
+
+class Schema extends Namespaced {
+  constructor(csdlDocument, namespace) {
+    super(csdlDocument, namespace);
+    csdlDocument.addChild(namespace, this);
+  }
+  get schema() {
+    return this;
+  }
+}
+
+class Record extends ModelElement {
+  fromJSON(json) {
+    super.fromJSON(json, "PropertyValue");
+  }
+}
+
+class Collection extends ModelElement {
+  #value;
+  get value() {
+    return this.#value;
+  }
+  set value(value) {
+    this.#value = value;
+  }
+  fromJSON(json) {
+    const value = [];
+    for (const item of json) {
+      Annotation.prototype.fromJSON.call(this, item);
+      value.push(this.value);
+    }
+    this.value = value;
+  }
+  toJSON() {
+    return this.value.map((item) =>
+      Annotation.prototype.toJSON.call(this, item),
+    );
+  }
+}
+
+class PropertyValue extends NamedModelElement {
+  #value;
+  get value() {
+    return this.#value;
+  }
+  set value(value) {
+    this.#value = value;
+  }
+  fromJSON(json) {
+    Annotation.prototype.fromJSON.call(this, json);
+  }
+  toJSON(json) {
+    return Annotation.prototype.toJSON.call(this, json);
+  }
+}
+
+class Path extends ModelElement {
+  constructor(host, path) {
+    super(host);
+    this.$Path = new RelativePath(this, path, host.evaluationStart());
+  }
+}
+
+class ComplexType extends NamedModelElement {
+  evaluateSegment(segment) {
+    return (
+      this.children[segment] || this.$BaseType.target.evaluateSegment(segment)
+    );
+  }
+  effectiveType() {
+    if (!this.$BaseType) return this;
+    const props = { ...this.$BaseType.effectiveType };
+    for (const prop in this.children)
+      if (prop in props) {
+        // TODO: Merge this.children[prop] into props[prop]
+      } else props[prop] = this.children[prop];
+    const effectiveType = new this.constructor(
+      new ModelElement(this),
+      this.name,
+    );
+    for (const prop in props) effectiveType.addChild(prop, props[prop]);
+    return effectiveType;
+  }
+  fromJSON(json) {
+    super.fromJSON(json, "Property");
+    if (json.$BaseType)
+      this.$BaseType = new NamespacePath(this, json.$BaseType);
+  }
+}
+
+class EntityType extends ComplexType {
+  effectiveType() {
+    const effectiveType = super.effectiveType();
+    if (effectiveType !== this)
+      for (let t = this; t; t = t.$BaseType?.target)
+        if (t.$Key) {
+          effectiveType.$Key = t.$Key;
+          break;
+        }
+    return effectiveType;
+  }
+  fromJSON(json) {
+    super.fromJSON(json);
+    if (json.$Key) {
+      this.$Key = new Key(this);
+      this.$Key.fromJSON(json.$Key);
+    }
+  }
+}
+
+class Key extends ModelElement {
+  #entityType;
+  #propertyRefs = [];
+  constructor(entityType) {
+    super(entityType);
+    this.#entityType = entityType;
+  }
+  fromJSON(json) {
+    // TODO: $Key annotations
+    for (const prop of json) {
+      let propRef;
+      if (typeof prop === "string")
+        propRef = new PropertyRef(
+          this,
+          prop,
+          new RelativePath(this, prop, this.#entityType),
+        );
+      else
+        for (const name in prop)
+          propRef = new PropertyRef(
+            this,
+            name,
+            new RelativePath(this, prop[name], this.#entityType),
+            true,
+          );
+      this.#propertyRefs.push(propRef);
+    }
+  }
+  toJSON() {
+    return this.#propertyRefs;
+  }
+}
+
+class PropertyRef extends NamedModelElement {
+  #path;
+  #alias;
+  constructor(key, name, path, alias) {
+    super(key, name);
+    this.#path = path;
+    this.#alias = alias;
+  }
+  get target() {
+    return this.#path.target;
+  }
+  toJSON() {
+    if (this.#alias) {
+      const propRef = {};
+      propRef[this.name] = this.#path;
+      return propRef;
+    } else return this.name;
+  }
+}
+
+class Property extends NamedModelElement {
+  evaluationStart() {
+    return this.parent;
+  }
+  fromJSON(json) {
+    super.fromJSON(json);
+    this.$Type = new NamespacePath(this, json.$Type || "Edm.String");
+  }
+  toJSON() {
+    const result = { ...this };
+    if (this.$Type.evaluate().toJSON() === "Edm.String") delete result.$Type;
+    return result;
+  }
+}
+
+class NavigationProperty extends NamedModelElement {
+  fromJSON(json) {
+    super.fromJSON(json);
+    this.$Type = new NamespacePath(this, json.$Type);
+  }
+}
+
+class EntityContainer extends NamedModelElement {
+  evaluateSegment(segment) {
+    return this.children[segment];
+  }
+  fromJSON(json) {
+    super.fromJSON(json, function (json) {
+      if (json.$Type) return "EntitySetOrSingleton";
+      if (json.$Function) return "FunctionImport";
+      if (json.$Action) return "ActionImport";
+    });
+  }
+}
+
+class EntitySetOrSingleton extends NamedModelElement {
+  evaluateSegment(segment) {
+    return this.$Type.target.evaluateSegment(segment);
+  }
+  fromJSON(json) {
+    super.fromJSON(json);
+    this.$Type = new NamespacePath(this, json.$Type);
+    for (const prop in json.$NavigationPropertyBinding)
+      new NavigationPropertyBinding(this, prop).fromJSON(
+        json.$NavigationPropertyBinding,
+      );
+  }
+}
+
+class NavigationPropertyBinding extends NamedSubElement {
+  #path;
+  constructor(entitySetOrSingleton, prop) {
+    super(entitySetOrSingleton, "$NavigationPropertyBinding", prop);
+  }
+  get path() {
+    return this.#path;
+  }
+  fromJSON(json) {
+    // TODO: $NavigationPropertyBinding annotations
+    this.#path = new RelativePath(this, json[this.name], this.parent.parent);
+  }
+  toJSON() {
+    return this.path.toJSON();
+  }
+}
+
+class Function extends ModelElement {}
+
+class FunctionImport extends NamedModelElement {
+  fromJSON(json) {
+    this.$Function = new NamespacePath(this, json.$Function);
+    if (json.$EntitySet)
+      this.$EntitySet = new RelativePath(this, json.$EntitySet, this.parent);
+    super.fromJSON(json);
+  }
+}
+
+function CSDLReviver(key, value) {
+  if (key === "") {
+    const csdl = new CSDLDocument();
+    csdl.fromJSON(value);
+    csdl.finish();
+    return csdl;
+  } else return value;
+}
+
+const closure = (module.exports = {
+  RelativePath,
+  NamespacePath,
+  CSDLDocument,
+  Reference,
+  Include,
+  IncludeAnnotations,
+  Schema,
+  Annotation,
+  Record,
+  Collection,
+  PropertyValue,
+  ComplexType,
+  EntityType,
+  Key,
+  PropertyRef,
+  Property,
+  NavigationProperty,
+  EntityContainer,
+  EntitySetOrSingleton,
+  NavigationPropertyBinding,
+  Function,
+  FunctionImport,
+  CSDLReviver,
+});
+
+debugger;
+global.csdl = JSON.parse(
+  require("fs").readFileSync(__dirname + "/../examples/csdl-16.1.json"),
+  CSDLReviver,
+);

--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -8,6 +8,13 @@
 // - extract preParser or at least checkElement* functions and their constants
 
 const sax = require("sax");
+const {
+  CSDL,
+  Reference,
+  Include,
+  IncludeAnnotations,
+  Schema,
+} = require("./metamodel");
 
 const VOCABULARIES = {
   Core: {
@@ -31,9 +38,9 @@ module.exports.xml2json = function (
     annotations = false,
     strict = false,
     messages = [],
-  } = {}
+  } = {},
 ) {
-  const result = {};
+  const result = new CSDL();
   const alias = { Edm: "Edm", odata: "odata" };
   const namespace = {};
   const namespaceUri = {};
@@ -71,7 +78,7 @@ module.exports.xml2json = function (
         break;
       case "DataServices": {
         const version = Object.values(node.attributes).find(
-          (attr) => attr.local == "DataServiceVersion"
+          (attr) => attr.local == "DataServiceVersion",
         );
         if (version) result.$Version = version.value;
         break;
@@ -137,7 +144,7 @@ module.exports.xml2json = function (
           preV4.current.associationEnd =
             preV4.current.association[node.attributes.Role.value] || {};
           preV4.current.associationEnd.type = normalizeTarget(
-            node.attributes.Type.value
+            node.attributes.Type.value,
           );
           checkAttribute(node, "Multiplicity");
           preV4.current.associationEnd.multiplicity =
@@ -166,7 +173,7 @@ module.exports.xml2json = function (
             dependentProperties: [],
           };
           preV4.referentialConstraints.push(
-            preV4.current.referentialConstraint
+            preV4.current.referentialConstraint,
           );
         }
         break;
@@ -183,7 +190,7 @@ module.exports.xml2json = function (
       case "PropertyRef":
         if (preV4.current.referentialConstraint)
           preV4.current.referentialConstraint.properties.push(
-            node.attributes.Name.value
+            node.attributes.Name.value,
           );
         break;
       case "Documentation":
@@ -496,7 +503,7 @@ module.exports.xml2json = function (
       else if (parser)
         reportError(
           `Element ${parent.local}, unexpected child: ${node.local}`,
-          parser
+          parser,
         );
       elements[0].skip = true;
       return false;
@@ -509,7 +516,7 @@ module.exports.xml2json = function (
       if (parser)
         reportError(
           `Element ${childName}: ${parent[childName].occ} occurrences instead of at most ${parentSchema[childName].max}`,
-          parser
+          parser,
         );
       elements[0].skip = true;
       return false;
@@ -548,7 +555,7 @@ module.exports.xml2json = function (
     ) {
       reportError(
         `Element ${node.local}: invalid or missing XML namespace: ${node.uri}`,
-        parser
+        parser,
       );
       return false;
     }
@@ -570,7 +577,7 @@ module.exports.xml2json = function (
 
     // check if all child elements have the correct minimum occurrence
     const required = Object.entries(SCHEMA[element.local] || {}).filter(
-      ([, v]) => v.min && v.min > 0
+      ([, v]) => v.min && v.min > 0,
     );
     for (const [name, constraints] of required) {
       if (!element[name] || element[name].occ < constraints.min) {
@@ -578,7 +585,7 @@ module.exports.xml2json = function (
           `Element ${local}, child element ${name}: ${
             element[name] ? element[name].occ : 0
           } occurrences instead of at least ${constraints.min}`,
-          parser
+          parser,
         );
       }
     }
@@ -668,51 +675,47 @@ module.exports.xml2json = function (
         break;
       case "Reference": {
         setAttributes(null, node, [], ["Uri"]);
-        current.reference = {};
         let uri = node.attributes.Uri.value;
         if (
           (uri.startsWith(
-            "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/"
+            "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/",
           ) ||
             uri.startsWith(
-              "https://sap.github.io/odata-vocabularies/vocabularies/"
+              "https://sap.github.io/odata-vocabularies/vocabularies/",
             )) &&
           uri.endsWith(".xml")
         )
           uri = uri.substring(0, uri.length - 3) + "json";
+        current.reference = new Reference(result, uri);
         if (!result.$Reference) result.$Reference = {};
         result.$Reference[uri] = current.reference;
         annotatable.target = current.reference;
         break;
       }
       case "Include":
-        current.include = {};
+        current.include = new Include(current.reference);
         setAttributes(current.include, node, ["Namespace", "Alias"]);
-        if (!current.reference.$Include) current.reference.$Include = [];
-        current.reference.$Include.push(current.include);
         annotatable.target = current.include;
         break;
       case "IncludeAnnotations":
         checkAttribute(node, "TermNamespace");
-        current.includeAnnotations = {};
+        current.includeAnnotations = new IncludeAnnotations(current.reference);
         setAttributes(current.includeAnnotations, node, [
           "TargetNamespace",
           "TermNamespace",
           "Qualifier",
         ]);
-        if (!current.reference.$IncludeAnnotations)
-          current.reference.$IncludeAnnotations = [];
-        current.reference.$IncludeAnnotations.push(current.includeAnnotations);
         annotatable.target = current.includeAnnotations;
         break;
       case "Schema":
-        current.schema = {};
-        current.schemaName = node.attributes.Namespace.value;
+        current.schema = new Schema(
+          result,
+          (current.schemaName = node.attributes.Namespace.value),
+        );
         setAttributes(current.schema, node, ["Alias"], ["Namespace"]);
         v2Annotations(current.schema, node, SAP_V2_SCHEMA);
         if (result[node.attributes.Namespace.value])
           reportError("Schema namespace collides with other schema", this);
-        result[node.attributes.Namespace.value] = current.schema;
         annotatable.target = current.schema;
         break;
       case "EntityType":
@@ -729,7 +732,7 @@ module.exports.xml2json = function (
         ]);
         if (result.$Version < "4.0") {
           const hasStream = Object.values(node.attributes).find(
-            (attr) => attr.local === "HasStream"
+            (attr) => attr.local === "HasStream",
           );
           if (hasStream && hasStream.value == "true")
             current.type.$HasStream = true;
@@ -799,7 +802,7 @@ module.exports.xml2json = function (
         if (current.type[node.attributes.Name.value])
           reportError(
             "Navigation property name collides with other property",
-            this
+            this,
           );
         current.type[node.attributes.Name.value] = current.property;
         annotatable.target = current.property;
@@ -845,7 +848,7 @@ module.exports.xml2json = function (
             "SRID",
             "DefaultValue",
           ],
-          result.$Version < "4.0" ? ["ConcurrencyMode", "FixedLength"] : []
+          result.$Version < "4.0" ? ["ConcurrencyMode", "FixedLength"] : [],
         );
         v2PropertyAnnotations(current.property, node);
         if (current.type[node.attributes.Name.value])
@@ -873,7 +876,7 @@ module.exports.xml2json = function (
         if (current.type[member] !== undefined)
           reportError(
             "Enumeration member name collides with other member",
-            this
+            this,
           );
         current.type[member] = Number.isNaN(value)
           ? current.enumMemberValue
@@ -951,7 +954,7 @@ module.exports.xml2json = function (
             "Scale",
             "SRID",
           ],
-          result.$Version < "4.0" ? ["Mode"] : []
+          result.$Version < "4.0" ? ["Mode"] : [],
         );
         v2Annotations(parameter, node, SAP_V2_PARAMETER);
         if (!current.overload.$Parameter) current.overload.$Parameter = [];
@@ -983,7 +986,7 @@ module.exports.xml2json = function (
         if (current.schema[node.attributes.Name.value])
           reportError(
             "Entity container name collides with other schema child",
-            this
+            this,
           );
         current.schema[node.attributes.Name.value] = current.container;
         annotatable.target = current.container;
@@ -1000,7 +1003,7 @@ module.exports.xml2json = function (
         if (current.container[node.attributes.Name.value])
           reportError(
             "Entity set name collides with other container child",
-            this
+            this,
           );
         current.container[node.attributes.Name.value] = current.containerChild;
         annotatable.target = current.containerChild;
@@ -1026,7 +1029,7 @@ module.exports.xml2json = function (
         if (current.container[node.attributes.Name.value])
           reportError(
             "Singleton name collides with other container child",
-            this
+            this,
           );
         current.container[node.attributes.Name.value] = current.containerChild;
         annotatable.target = current.containerChild;
@@ -1039,7 +1042,7 @@ module.exports.xml2json = function (
         if (current.container[node.attributes.Name.value])
           reportError(
             "Action import name collides with other container child",
-            this
+            this,
           );
         current.container[node.attributes.Name.value] = current.containerChild;
         annotatable.target = current.containerChild;
@@ -1049,7 +1052,7 @@ module.exports.xml2json = function (
         current.containerChild = {};
         if (result.$Version < "4.0") {
           const method = Object.values(node.attributes).find(
-            (attr) => attr.local == "HttpMethod"
+            (attr) => attr.local == "HttpMethod",
           );
           const operationName =
             current.schemaName + "." + node.attributes.Name.value;
@@ -1096,7 +1099,7 @@ module.exports.xml2json = function (
             current.containerChild,
             node,
             ["EntitySet"],
-            ["ReturnType", "IsBindable", "IsSideEffecting"]
+            ["ReturnType", "IsBindable", "IsSideEffecting"],
           );
           const returnType = node.attributes.ReturnType;
           if (returnType) {
@@ -1105,7 +1108,7 @@ module.exports.xml2json = function (
               current.overload.$ReturnType,
               node,
               ["ReturnType"],
-              ["EntitySet", "IsBindable", "IsSideEffecting"]
+              ["EntitySet", "IsBindable", "IsSideEffecting"],
             );
           }
           current.schema[node.attributes.Name.value] = [current.overload];
@@ -1119,7 +1122,7 @@ module.exports.xml2json = function (
           if (current.container[node.attributes.Name.value])
             reportError(
               "Function import name collides with other container child",
-              this
+              this,
             );
           current.container[node.attributes.Name.value] =
             current.containerChild;
@@ -1187,7 +1190,7 @@ module.exports.xml2json = function (
         setAttributes(
           annotation,
           node,
-          ["Term", "Qualifier"].concat(attributeExpressions)
+          ["Term", "Qualifier"].concat(attributeExpressions),
         );
         current.annotation.unshift(annotation);
         annotatable.target = current.annotatable[0].target;
@@ -1215,7 +1218,7 @@ module.exports.xml2json = function (
         setAttributes(
           annotation,
           node,
-          ["Property"].concat(attributeExpressions)
+          ["Property"].concat(attributeExpressions),
         );
         current.annotation.unshift(annotation);
         annotatable.target = current.annotatable[0].target;
@@ -1392,7 +1395,7 @@ module.exports.xml2json = function (
         }
         updateValue(
           current.annotation[0],
-          current.text.replace(/\r\n|\r(?!\n)/g, "\n")
+          current.text.replace(/\r\n|\r(?!\n)/g, "\n"),
         );
         current.text = null;
       // fall through
@@ -1520,7 +1523,7 @@ module.exports.xml2json = function (
       case "String":
         updateValue(
           current.annotation[0],
-          current.text.replace(/\r\n|\r(?!\n)/g, "\n")
+          current.text.replace(/\r\n|\r(?!\n)/g, "\n"),
         );
         current.text = null;
         break;
@@ -1529,7 +1532,7 @@ module.exports.xml2json = function (
       case "Int":
         updateValue(
           current.annotation[0],
-          isNaN(current.text) ? current.text : Number(current.text)
+          isNaN(current.text) ? current.text : Number(current.text),
         );
         current.text = null;
         break;
@@ -1737,7 +1740,7 @@ module.exports.xml2json = function (
             ) {
               reportError(
                 `Element ${node.local}, Type=Collection(Edm.EntityType) with Nullable attribute`,
-                parser
+                parser,
               );
               break;
             }
@@ -1867,7 +1870,7 @@ module.exports.xml2json = function (
           case "String":
             target.value = node.attributes[name].value.replace(
               /\r\n|\r(?!\n)/g,
-              "\n"
+              "\n",
             );
             break;
           case "Binary":
@@ -1905,7 +1908,7 @@ module.exports.xml2json = function (
         ) {
           reportError(
             `Element ${node.local}, Type=Collection without Nullable attribute`,
-            parser
+            parser,
           );
         } else if (
           name === "Nullable" &&
@@ -1937,7 +1940,7 @@ module.exports.xml2json = function (
     ) {
       reportError(
         "Element NavigationProperty, Type=Collection(...) with Nullable attribute",
-        parser
+        parser,
       );
       delete target.$Nullable;
     }
@@ -1948,13 +1951,13 @@ module.exports.xml2json = function (
           a.prefix === "" &&
           a.local !== "Name" &&
           !extract.includes(a.local) &&
-          !ignore.includes(a.local)
+          !ignore.includes(a.local),
       )
       .forEach((attribute) => {
         // Note: setAttributes is only called within callbacks of parser
         reportError(
           `Element ${node.local}, unexpected attribute: ${attribute.name}`,
-          parser
+          parser,
         );
       });
     if (annotations) {
@@ -1966,7 +1969,7 @@ module.exports.xml2json = function (
             a.prefix != "" &&
             a.prefix != "xmlns" &&
             a.uri !=
-              "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+              "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata",
         )
         .forEach((attribute) => {
           if (!result.$Reference) result.$Reference = {};
@@ -1988,8 +1991,8 @@ module.exports.xml2json = function (
             attribute.value === "true"
               ? true
               : attribute.value === "false"
-              ? false
-              : attribute.value;
+                ? false
+                : attribute.value;
         });
     }
   }
@@ -2079,7 +2082,7 @@ module.exports.xml2json = function (
   function v2Annotations(target, node, annotationsMap) {
     if (result.$Version !== "2.0") return;
     const attributes = Object.values(node.attributes).filter(
-      (a) => a.uri === SAP_V2_URI
+      (a) => a.uri === SAP_V2_URI,
     );
     for (const attribute of attributes) {
       const anno = annotationsMap[attribute.local];
@@ -2145,7 +2148,7 @@ module.exports.xml2json = function (
             if (!preV4.nonFilterable[current.qualifiedTypeName])
               preV4.nonFilterable[current.qualifiedTypeName] = [];
             preV4.nonFilterable[current.qualifiedTypeName].push(
-              node.attributes.Name.value
+              node.attributes.Name.value,
             );
           }
           break;
@@ -2168,7 +2171,7 @@ module.exports.xml2json = function (
             if (!preV4.requiredInFilter[current.qualifiedTypeName])
               preV4.requiredInFilter[current.qualifiedTypeName] = [];
             preV4.requiredInFilter[current.qualifiedTypeName].push(
-              node.attributes.Name.value
+              node.attributes.Name.value,
             );
           }
           break;
@@ -2178,7 +2181,7 @@ module.exports.xml2json = function (
             if (!preV4.nonSortable[current.qualifiedTypeName])
               preV4.nonSortable[current.qualifiedTypeName] = [];
             preV4.nonSortable[current.qualifiedTypeName].push(
-              node.attributes.Name.value
+              node.attributes.Name.value,
             );
           }
           break;
@@ -2212,7 +2215,7 @@ module.exports.xml2json = function (
     alias[VOCABULARIES.Capabilities.Namespace]
   }.SortRestrictions`;
   for (const set of Object.values(current.container).filter(
-    (c) => c.$Collection
+    (c) => c.$Collection,
   )) {
     if (preV4.nonFilterable[set.$Type]) {
       if (!set[FILTER_RESTRICTIONS]) set[FILTER_RESTRICTIONS] = {};
@@ -2222,7 +2225,7 @@ module.exports.xml2json = function (
     if (preV4.filterRestrictions[set.$Type]) {
       if (!set[FILTER_RESTRICTIONS]) set[FILTER_RESTRICTIONS] = {};
       set[FILTER_RESTRICTIONS].FilterExpressionRestrictions = Object.entries(
-        preV4.filterRestrictions[set.$Type]
+        preV4.filterRestrictions[set.$Type],
       ).map(([k, v]) => ({ Property: k, AllowedExpressions: v }));
     }
     if (preV4.requiredInFilter[set.$Type]) {

--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -8,13 +8,6 @@
 // - extract preParser or at least checkElement* functions and their constants
 
 const sax = require("sax");
-const {
-  CSDL,
-  Reference,
-  Include,
-  IncludeAnnotations,
-  Schema,
-} = require("./metamodel");
 
 const VOCABULARIES = {
   Core: {
@@ -38,9 +31,9 @@ module.exports.xml2json = function (
     annotations = false,
     strict = false,
     messages = [],
-  } = {},
+  } = {}
 ) {
-  const result = new CSDL();
+  const result = {};
   const alias = { Edm: "Edm", odata: "odata" };
   const namespace = {};
   const namespaceUri = {};
@@ -78,7 +71,7 @@ module.exports.xml2json = function (
         break;
       case "DataServices": {
         const version = Object.values(node.attributes).find(
-          (attr) => attr.local == "DataServiceVersion",
+          (attr) => attr.local == "DataServiceVersion"
         );
         if (version) result.$Version = version.value;
         break;
@@ -144,7 +137,7 @@ module.exports.xml2json = function (
           preV4.current.associationEnd =
             preV4.current.association[node.attributes.Role.value] || {};
           preV4.current.associationEnd.type = normalizeTarget(
-            node.attributes.Type.value,
+            node.attributes.Type.value
           );
           checkAttribute(node, "Multiplicity");
           preV4.current.associationEnd.multiplicity =
@@ -173,7 +166,7 @@ module.exports.xml2json = function (
             dependentProperties: [],
           };
           preV4.referentialConstraints.push(
-            preV4.current.referentialConstraint,
+            preV4.current.referentialConstraint
           );
         }
         break;
@@ -190,7 +183,7 @@ module.exports.xml2json = function (
       case "PropertyRef":
         if (preV4.current.referentialConstraint)
           preV4.current.referentialConstraint.properties.push(
-            node.attributes.Name.value,
+            node.attributes.Name.value
           );
         break;
       case "Documentation":
@@ -503,7 +496,7 @@ module.exports.xml2json = function (
       else if (parser)
         reportError(
           `Element ${parent.local}, unexpected child: ${node.local}`,
-          parser,
+          parser
         );
       elements[0].skip = true;
       return false;
@@ -516,7 +509,7 @@ module.exports.xml2json = function (
       if (parser)
         reportError(
           `Element ${childName}: ${parent[childName].occ} occurrences instead of at most ${parentSchema[childName].max}`,
-          parser,
+          parser
         );
       elements[0].skip = true;
       return false;
@@ -555,7 +548,7 @@ module.exports.xml2json = function (
     ) {
       reportError(
         `Element ${node.local}: invalid or missing XML namespace: ${node.uri}`,
-        parser,
+        parser
       );
       return false;
     }
@@ -577,7 +570,7 @@ module.exports.xml2json = function (
 
     // check if all child elements have the correct minimum occurrence
     const required = Object.entries(SCHEMA[element.local] || {}).filter(
-      ([, v]) => v.min && v.min > 0,
+      ([, v]) => v.min && v.min > 0
     );
     for (const [name, constraints] of required) {
       if (!element[name] || element[name].occ < constraints.min) {
@@ -585,7 +578,7 @@ module.exports.xml2json = function (
           `Element ${local}, child element ${name}: ${
             element[name] ? element[name].occ : 0
           } occurrences instead of at least ${constraints.min}`,
-          parser,
+          parser
         );
       }
     }
@@ -675,47 +668,51 @@ module.exports.xml2json = function (
         break;
       case "Reference": {
         setAttributes(null, node, [], ["Uri"]);
+        current.reference = {};
         let uri = node.attributes.Uri.value;
         if (
           (uri.startsWith(
-            "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/",
+            "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/"
           ) ||
             uri.startsWith(
-              "https://sap.github.io/odata-vocabularies/vocabularies/",
+              "https://sap.github.io/odata-vocabularies/vocabularies/"
             )) &&
           uri.endsWith(".xml")
         )
           uri = uri.substring(0, uri.length - 3) + "json";
-        current.reference = new Reference(result, uri);
         if (!result.$Reference) result.$Reference = {};
         result.$Reference[uri] = current.reference;
         annotatable.target = current.reference;
         break;
       }
       case "Include":
-        current.include = new Include(current.reference);
+        current.include = {};
         setAttributes(current.include, node, ["Namespace", "Alias"]);
+        if (!current.reference.$Include) current.reference.$Include = [];
+        current.reference.$Include.push(current.include);
         annotatable.target = current.include;
         break;
       case "IncludeAnnotations":
         checkAttribute(node, "TermNamespace");
-        current.includeAnnotations = new IncludeAnnotations(current.reference);
+        current.includeAnnotations = {};
         setAttributes(current.includeAnnotations, node, [
           "TargetNamespace",
           "TermNamespace",
           "Qualifier",
         ]);
+        if (!current.reference.$IncludeAnnotations)
+          current.reference.$IncludeAnnotations = [];
+        current.reference.$IncludeAnnotations.push(current.includeAnnotations);
         annotatable.target = current.includeAnnotations;
         break;
       case "Schema":
-        current.schema = new Schema(
-          result,
-          (current.schemaName = node.attributes.Namespace.value),
-        );
+        current.schema = {};
+        current.schemaName = node.attributes.Namespace.value;
         setAttributes(current.schema, node, ["Alias"], ["Namespace"]);
         v2Annotations(current.schema, node, SAP_V2_SCHEMA);
         if (result[node.attributes.Namespace.value])
           reportError("Schema namespace collides with other schema", this);
+        result[node.attributes.Namespace.value] = current.schema;
         annotatable.target = current.schema;
         break;
       case "EntityType":
@@ -732,7 +729,7 @@ module.exports.xml2json = function (
         ]);
         if (result.$Version < "4.0") {
           const hasStream = Object.values(node.attributes).find(
-            (attr) => attr.local === "HasStream",
+            (attr) => attr.local === "HasStream"
           );
           if (hasStream && hasStream.value == "true")
             current.type.$HasStream = true;
@@ -802,7 +799,7 @@ module.exports.xml2json = function (
         if (current.type[node.attributes.Name.value])
           reportError(
             "Navigation property name collides with other property",
-            this,
+            this
           );
         current.type[node.attributes.Name.value] = current.property;
         annotatable.target = current.property;
@@ -848,7 +845,7 @@ module.exports.xml2json = function (
             "SRID",
             "DefaultValue",
           ],
-          result.$Version < "4.0" ? ["ConcurrencyMode", "FixedLength"] : [],
+          result.$Version < "4.0" ? ["ConcurrencyMode", "FixedLength"] : []
         );
         v2PropertyAnnotations(current.property, node);
         if (current.type[node.attributes.Name.value])
@@ -876,7 +873,7 @@ module.exports.xml2json = function (
         if (current.type[member] !== undefined)
           reportError(
             "Enumeration member name collides with other member",
-            this,
+            this
           );
         current.type[member] = Number.isNaN(value)
           ? current.enumMemberValue
@@ -954,7 +951,7 @@ module.exports.xml2json = function (
             "Scale",
             "SRID",
           ],
-          result.$Version < "4.0" ? ["Mode"] : [],
+          result.$Version < "4.0" ? ["Mode"] : []
         );
         v2Annotations(parameter, node, SAP_V2_PARAMETER);
         if (!current.overload.$Parameter) current.overload.$Parameter = [];
@@ -986,7 +983,7 @@ module.exports.xml2json = function (
         if (current.schema[node.attributes.Name.value])
           reportError(
             "Entity container name collides with other schema child",
-            this,
+            this
           );
         current.schema[node.attributes.Name.value] = current.container;
         annotatable.target = current.container;
@@ -1003,7 +1000,7 @@ module.exports.xml2json = function (
         if (current.container[node.attributes.Name.value])
           reportError(
             "Entity set name collides with other container child",
-            this,
+            this
           );
         current.container[node.attributes.Name.value] = current.containerChild;
         annotatable.target = current.containerChild;
@@ -1029,7 +1026,7 @@ module.exports.xml2json = function (
         if (current.container[node.attributes.Name.value])
           reportError(
             "Singleton name collides with other container child",
-            this,
+            this
           );
         current.container[node.attributes.Name.value] = current.containerChild;
         annotatable.target = current.containerChild;
@@ -1042,7 +1039,7 @@ module.exports.xml2json = function (
         if (current.container[node.attributes.Name.value])
           reportError(
             "Action import name collides with other container child",
-            this,
+            this
           );
         current.container[node.attributes.Name.value] = current.containerChild;
         annotatable.target = current.containerChild;
@@ -1052,7 +1049,7 @@ module.exports.xml2json = function (
         current.containerChild = {};
         if (result.$Version < "4.0") {
           const method = Object.values(node.attributes).find(
-            (attr) => attr.local == "HttpMethod",
+            (attr) => attr.local == "HttpMethod"
           );
           const operationName =
             current.schemaName + "." + node.attributes.Name.value;
@@ -1099,7 +1096,7 @@ module.exports.xml2json = function (
             current.containerChild,
             node,
             ["EntitySet"],
-            ["ReturnType", "IsBindable", "IsSideEffecting"],
+            ["ReturnType", "IsBindable", "IsSideEffecting"]
           );
           const returnType = node.attributes.ReturnType;
           if (returnType) {
@@ -1108,7 +1105,7 @@ module.exports.xml2json = function (
               current.overload.$ReturnType,
               node,
               ["ReturnType"],
-              ["EntitySet", "IsBindable", "IsSideEffecting"],
+              ["EntitySet", "IsBindable", "IsSideEffecting"]
             );
           }
           current.schema[node.attributes.Name.value] = [current.overload];
@@ -1122,7 +1119,7 @@ module.exports.xml2json = function (
           if (current.container[node.attributes.Name.value])
             reportError(
               "Function import name collides with other container child",
-              this,
+              this
             );
           current.container[node.attributes.Name.value] =
             current.containerChild;
@@ -1190,7 +1187,7 @@ module.exports.xml2json = function (
         setAttributes(
           annotation,
           node,
-          ["Term", "Qualifier"].concat(attributeExpressions),
+          ["Term", "Qualifier"].concat(attributeExpressions)
         );
         current.annotation.unshift(annotation);
         annotatable.target = current.annotatable[0].target;
@@ -1218,7 +1215,7 @@ module.exports.xml2json = function (
         setAttributes(
           annotation,
           node,
-          ["Property"].concat(attributeExpressions),
+          ["Property"].concat(attributeExpressions)
         );
         current.annotation.unshift(annotation);
         annotatable.target = current.annotatable[0].target;
@@ -1395,7 +1392,7 @@ module.exports.xml2json = function (
         }
         updateValue(
           current.annotation[0],
-          current.text.replace(/\r\n|\r(?!\n)/g, "\n"),
+          current.text.replace(/\r\n|\r(?!\n)/g, "\n")
         );
         current.text = null;
       // fall through
@@ -1523,7 +1520,7 @@ module.exports.xml2json = function (
       case "String":
         updateValue(
           current.annotation[0],
-          current.text.replace(/\r\n|\r(?!\n)/g, "\n"),
+          current.text.replace(/\r\n|\r(?!\n)/g, "\n")
         );
         current.text = null;
         break;
@@ -1532,7 +1529,7 @@ module.exports.xml2json = function (
       case "Int":
         updateValue(
           current.annotation[0],
-          isNaN(current.text) ? current.text : Number(current.text),
+          isNaN(current.text) ? current.text : Number(current.text)
         );
         current.text = null;
         break;
@@ -1740,7 +1737,7 @@ module.exports.xml2json = function (
             ) {
               reportError(
                 `Element ${node.local}, Type=Collection(Edm.EntityType) with Nullable attribute`,
-                parser,
+                parser
               );
               break;
             }
@@ -1870,7 +1867,7 @@ module.exports.xml2json = function (
           case "String":
             target.value = node.attributes[name].value.replace(
               /\r\n|\r(?!\n)/g,
-              "\n",
+              "\n"
             );
             break;
           case "Binary":
@@ -1908,7 +1905,7 @@ module.exports.xml2json = function (
         ) {
           reportError(
             `Element ${node.local}, Type=Collection without Nullable attribute`,
-            parser,
+            parser
           );
         } else if (
           name === "Nullable" &&
@@ -1940,7 +1937,7 @@ module.exports.xml2json = function (
     ) {
       reportError(
         "Element NavigationProperty, Type=Collection(...) with Nullable attribute",
-        parser,
+        parser
       );
       delete target.$Nullable;
     }
@@ -1951,13 +1948,13 @@ module.exports.xml2json = function (
           a.prefix === "" &&
           a.local !== "Name" &&
           !extract.includes(a.local) &&
-          !ignore.includes(a.local),
+          !ignore.includes(a.local)
       )
       .forEach((attribute) => {
         // Note: setAttributes is only called within callbacks of parser
         reportError(
           `Element ${node.local}, unexpected attribute: ${attribute.name}`,
-          parser,
+          parser
         );
       });
     if (annotations) {
@@ -1969,7 +1966,7 @@ module.exports.xml2json = function (
             a.prefix != "" &&
             a.prefix != "xmlns" &&
             a.uri !=
-              "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata",
+              "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
         )
         .forEach((attribute) => {
           if (!result.$Reference) result.$Reference = {};
@@ -1991,8 +1988,8 @@ module.exports.xml2json = function (
             attribute.value === "true"
               ? true
               : attribute.value === "false"
-                ? false
-                : attribute.value;
+              ? false
+              : attribute.value;
         });
     }
   }
@@ -2082,7 +2079,7 @@ module.exports.xml2json = function (
   function v2Annotations(target, node, annotationsMap) {
     if (result.$Version !== "2.0") return;
     const attributes = Object.values(node.attributes).filter(
-      (a) => a.uri === SAP_V2_URI,
+      (a) => a.uri === SAP_V2_URI
     );
     for (const attribute of attributes) {
       const anno = annotationsMap[attribute.local];
@@ -2148,7 +2145,7 @@ module.exports.xml2json = function (
             if (!preV4.nonFilterable[current.qualifiedTypeName])
               preV4.nonFilterable[current.qualifiedTypeName] = [];
             preV4.nonFilterable[current.qualifiedTypeName].push(
-              node.attributes.Name.value,
+              node.attributes.Name.value
             );
           }
           break;
@@ -2171,7 +2168,7 @@ module.exports.xml2json = function (
             if (!preV4.requiredInFilter[current.qualifiedTypeName])
               preV4.requiredInFilter[current.qualifiedTypeName] = [];
             preV4.requiredInFilter[current.qualifiedTypeName].push(
-              node.attributes.Name.value,
+              node.attributes.Name.value
             );
           }
           break;
@@ -2181,7 +2178,7 @@ module.exports.xml2json = function (
             if (!preV4.nonSortable[current.qualifiedTypeName])
               preV4.nonSortable[current.qualifiedTypeName] = [];
             preV4.nonSortable[current.qualifiedTypeName].push(
-              node.attributes.Name.value,
+              node.attributes.Name.value
             );
           }
           break;
@@ -2215,7 +2212,7 @@ module.exports.xml2json = function (
     alias[VOCABULARIES.Capabilities.Namespace]
   }.SortRestrictions`;
   for (const set of Object.values(current.container).filter(
-    (c) => c.$Collection,
+    (c) => c.$Collection
   )) {
     if (preV4.nonFilterable[set.$Type]) {
       if (!set[FILTER_RESTRICTIONS]) set[FILTER_RESTRICTIONS] = {};
@@ -2225,7 +2222,7 @@ module.exports.xml2json = function (
     if (preV4.filterRestrictions[set.$Type]) {
       if (!set[FILTER_RESTRICTIONS]) set[FILTER_RESTRICTIONS] = {};
       set[FILTER_RESTRICTIONS].FilterExpressionRestrictions = Object.entries(
-        preV4.filterRestrictions[set.$Type],
+        preV4.filterRestrictions[set.$Type]
       ).map(([k, v]) => ({ Property: k, AllowedExpressions: v }));
     }
     if (preV4.requiredInFilter[set.$Type]) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "odata-csdl-xml2json": "lib/cli.js"
   },
   "main": "lib/xml2json.js",
+  "exports": {
+    ".": "./lib/xml2json.js",
+    "./metamodel": "./lib/metamodel.js"
+  },
   "dependencies": {
     "colors": "^1.4.0",
     "sax": "^1.4.1"

--- a/test/xml2json.test.js
+++ b/test/xml2json.test.js
@@ -5,7 +5,6 @@
 
 const assert = require("assert");
 const fs = require("fs");
-const { CSDL } = require("../lib/metamodel");
 
 const csdl = require("../lib/xml2json");
 
@@ -1814,7 +1813,7 @@ describe("Error cases", function () {
       },
     ]);
 
-    assert.deepStrictEqual(json, new CSDL({
+    assert.deepStrictEqual(json, {
       $Version: "4.0",
       $EntityContainer: "foo.container",
       foo: {
@@ -1832,6 +1831,6 @@ describe("Error cases", function () {
           bar: { $Function: "foo.bar" },
         },
       },
-    }));
+    });
   });
 });

--- a/test/xml2json.test.js
+++ b/test/xml2json.test.js
@@ -5,6 +5,7 @@
 
 const assert = require("assert");
 const fs = require("fs");
+const { CSDL } = require("../lib/metamodel");
 
 const csdl = require("../lib/xml2json");
 
@@ -1813,7 +1814,7 @@ describe("Error cases", function () {
       },
     ]);
 
-    assert.deepStrictEqual(json, {
+    assert.deepStrictEqual(json, new CSDL({
       $Version: "4.0",
       $EntityContainer: "foo.container",
       foo: {
@@ -1831,6 +1832,6 @@ describe("Error cases", function () {
           bar: { $Function: "foo.bar" },
         },
       },
-    });
+    }));
   });
 });


### PR DESCRIPTION
A collection of Javascript classes with the following properties:
- `JSON.parse(fs.readFileSync("csdl.json"), CSDLReviver)` gives an instance of `CSDLDocument`
- `JSON.stringify(instanceOfCSDLDocument)` gives the CSDL JSON format

and the following helper methods:
- `path.target` is the model element targeted by the path (possibly in a $Referenced CSDL document)
- `modelElement.targetingPaths()` gives a set of paths targeting the model element
- `modelElement.targetingSegments()` gives a set of non-final path segments targeting the model element
- `structuredType.effectiveType()` gives a structured type including inherited properties

This Javascript object model is meant to help with the generation of additional documents for a CSDL model, like the Markdown documentation or the OpenAPI document. For example
- the Markdown generation currently employs an adhoc algorithm to compute the `effectiveType`.
- the XSLT-based OpenAPI generation currently does not consider whether a property is targeted by a `Measures.ISOCurrency` annotation.